### PR TITLE
Fix brokenpipe

### DIFF
--- a/SipiHttpServer.cpp
+++ b/SipiHttpServer.cpp
@@ -36,6 +36,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <unistd.h>
+
 #include "SipiImage.h"
 #include "SipiError.h"
 #include "iiifparser/SipiRegion.h"
@@ -922,7 +923,7 @@ namespace Sipi {
                     catch (SipiImageError &err) {
                         if (cache != NULL) {
                             conobj.closeCacheFile();
-                            // ToDo: remove incomplete cache file!
+                            unlink(cachefile.c_str());
                         }
                         break;
                     }

--- a/SipiHttpServer.cpp
+++ b/SipiHttpServer.cpp
@@ -916,7 +916,16 @@ namespace Sipi {
                         conobj.openCacheFile(cachefile);
                     }
                     logger->debug("Before writing JPG...");
-                    img.write("jpg", "HTTP");
+                    try {
+                        img.write("jpg", "HTTP");
+                    }
+                    catch (SipiImageError &err) {
+                        if (cache != NULL) {
+                            conobj.closeCacheFile();
+                            // ToDo: remove incomplete cache file!
+                        }
+                        break;
+                    }
                     logger->debug("After writing JPG...");
                     if (cache != NULL) {
                         conobj.closeCacheFile();

--- a/SipiImage.h
+++ b/SipiImage.h
@@ -87,8 +87,17 @@ namespace Sipi {
         SKIP_ALL = 0xFF
     } SkipMetadata;
 
+    class SipiImageError : public std::runtime_error {
+    public:
+        inline SipiImageError() : runtime_error("SipiImageError") {}
+        inline SipiImageError(const char *msg) : runtime_error(msg) {}
+        inline const char* what() const noexcept {
+            return runtime_error::what();
+        }
+    };
 
-   /*!
+
+    /*!
     * \class SipiImage
     *
     * Base class for all images in the Sipi package.

--- a/formats/SipiIOJ2k.cpp
+++ b/formats/SipiIOJ2k.cpp
@@ -101,7 +101,12 @@ namespace Sipi {
     //........................................................................
     bool J2kHttpStream::write( const kdu_byte * buf, int num_bytes)
     {
-        conobj->sendAndFlush(buf, num_bytes);
+        try {
+            conobj->sendAndFlush(buf, num_bytes);
+        }
+        catch (int i) {
+            return false;
+        }
         return true;
     };
     //-------------------------------------------------------------------------

--- a/formats/SipiIOJpeg.cpp
+++ b/formats/SipiIOJpeg.cpp
@@ -476,6 +476,9 @@ namespace Sipi {
 
 
     void SipiIOJpeg::write(SipiImage *img, std::string filepath, int quality) {
+        //
+        // TODO! Support incoming 16 bit images by converting the buffer to 8 bit!
+        //
         struct jpeg_compress_struct cinfo;
         struct jpeg_error_mgr jerr;
 

--- a/formats/SipiIOPng.cpp
+++ b/formats/SipiIOPng.cpp
@@ -341,6 +341,10 @@ namespace Sipi {
     /*==========================================================================*/
 
     void SipiIOPng::write(SipiImage *img, std::string filepath, int quality) {
+        //
+        // TODO! Support incoming 16 bit images may be (!!) by converting the buffer to 8 bit!
+        //
+
         FILE *outfile = NULL;
         png_structp png_ptr;
         shttps::Connection *conobj = img->connection();

--- a/formats/SipiIOPng.cpp
+++ b/formats/SipiIOPng.cpp
@@ -319,13 +319,24 @@ namespace Sipi {
 
     static void conn_write_data(png_structp png_ptr, png_bytep data, png_size_t length) {
         shttps::Connection *conn = (shttps::Connection *) png_get_io_ptr(png_ptr);
-        conn->sendAndFlush(data, length);
+        try {
+            conn->sendAndFlush(data, length);
+        }
+        catch (int i) {
+            // TODO: do nothing ??
+        }
+
     }
     /*==========================================================================*/
 
     static void conn_flush_data(png_structp png_ptr) {
         shttps::Connection *conn = (shttps::Connection *) png_get_io_ptr(png_ptr);
-        conn->flush();
+        try {
+            conn->flush();
+        }
+        catch (int i) {
+            // TODO: do nothing ??
+        }
     }
     /*==========================================================================*/
 

--- a/formats/SipiIOTiff.cpp
+++ b/formats/SipiIOTiff.cpp
@@ -1024,7 +1024,13 @@ namespace Sipi {
             }
             else if (filepath == "HTTP") {
                 shttps::Connection *conobj = img->connection();
-                conobj->sendAndFlush(memtif->data, memtif->flen);
+                try {
+                    conobj->sendAndFlush(memtif->data, memtif->flen);
+                }
+                catch (int i) {
+                    memTiffFree(memtif);
+                    throw SipiError(__file__, __LINE__, "Sending data failed! Broken pipe?: " + filepath + " !");
+                }
             }
             else {
                 memTiffFree(memtif);

--- a/shttps/Connection.cpp
+++ b/shttps/Connection.cpp
@@ -719,7 +719,12 @@ namespace shttps {
 
     Connection::~Connection()
     {
-        finalize();
+        try {
+            finalize();
+        }
+        catch (int i) {
+            // do nothing....
+        }
         if (outbuf != NULL) {
             free (outbuf);
         }

--- a/shttps/Error.h
+++ b/shttps/Error.h
@@ -35,7 +35,7 @@ namespace shttps {
    /*!
     * \brief Class used to thow errors from the web server implementation
     *
-    * This class which inherits from \class std::runtime_error is used to thow catchable
+    * This class which inherits from \class std::runtime_error is used to throw catchable
     * errors from the web server. The error contains the cpp-file, line number, a user given
     * description and, if available, the system error message.
     */

--- a/shttps/LuaServer.cpp
+++ b/shttps/LuaServer.cpp
@@ -32,7 +32,10 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <unistd.h>
+#include <sys/socket.h>
+#include <netdb.h>
 
+#include "SockStream.h"
 #include "LuaServer.h"
 #include "Connection.h"
 #include "Server.h"
@@ -582,7 +585,107 @@ namespace shttps {
         return 0;
     }
     //=========================================================================
+#ifdef GAGA
 
+    static string get_host_name() {
+        struct addrinfo hints, *info, *p;
+        int gai_result;
+
+        char hostname[1024];
+        hostname[1023] = '\0';
+        gethostname(hostname, 1023);
+
+        string result;
+
+        memset(&hints, 0, sizeof hints);
+        hints.ai_family = AF_UNSPEC; /*either IPV4 or IPV6*/
+        hints.ai_socktype = SOCK_STREAM;
+        hints.ai_flags = AI_CANONNAME;
+
+        if ((gai_result = getaddrinfo(hostname, "http", &hints, &info)) != 0) {
+            return result;
+        }
+
+        if (p != NULL) {
+            result = p->ai_canonname;
+        }
+
+        freeaddrinfo(info);
+
+        return result;
+    }
+
+    /*!
+     * Get's data from a http server
+     * LUA server.http("GET", "http://server.domain/path/file" [, header])
+     * where header is an associative array (key-value pairs) of header variables
+     */
+    static int lua_http_client(lua_State *L) {
+        int top = lua_gettop(L);
+        if (top < 2) {
+            lua_pushstring(L, "Lua-error 'server.http(method, url, [header])' requires at least 2 parameters");
+            lua_error(L);
+            return 0;
+        }
+        const char *_method = lua_tostring(L, 1);
+        string method = _method;
+        const char *_url = lua_tostring(L, 2);
+        string url = _url;
+
+        if (method == "GET") {
+            struct addrinfo *ai;
+            struct addrinfo hint;
+            memset(&hints, 0, sizeof hints);
+            hints.ai_family = PF_INET;
+            hints.ai_socktype = SOCK_STREAM;
+            hints.ai_protocol = IPPROTO_TCP;
+            if (getaddrinfo(url.c_str(), NULL, &hints, &ai) != 0) {
+                lua_pop(L, top);
+                lua_pushstring(L, "Lua-error 'server.http(method, url, [header])': Could not resolve hostname");
+                lua_error(L);
+                return 0;
+            }
+
+            int socketfd;
+            if ((sockfd = socket(ai->ai_family, ai->ai_socktype, ai->ai_protocol)) == -1) {
+                lua_pop(L, top);
+                freeaddrinfo(ai);
+                perror("socket");
+                lua_pushstring(L, "Lua-error 'server.http(method, url, [header])': Could not create socket");
+                lua_error(L);
+                return 0;
+            }
+
+            if (connect(sockfd, p->ai_addr, p->ai_addrlen) == -1) {
+                close(sockfd);
+                lua_pop(L, top);
+                freeaddrinfo(ai);
+                perror("socket");
+                lua_pushstring(L, "Lua-error 'server.http(method, url, [header])': Could not create socket");
+                lua_error(L);
+                return 0;
+            }
+
+            SockStream sockstream(sock);
+            istream ins(&sockstream);
+            ostream os(&sockstream);
+
+            os << "GET " << path << "HTTP/1.1\r\n";
+            string myhost = get_host_name();
+            if (!myhost.empty()) {
+                os << "Host: " << myhost << "\r\n";
+            }
+
+            freeaddrinfo(ai);
+        }
+        else {
+            lua_pushstring(L, "Lua-error 'server.http(method, url, [header])': unknown method");
+            lua_error(L);
+        }
+
+    }
+    //=========================================================================
+#endif
 
     static cJSON *subtable(lua_State *L) {
         const char table_error[] = "server.table_to_json(table): datatype inconsistency!";

--- a/shttps/SockStream.cpp
+++ b/shttps/SockStream.cpp
@@ -28,7 +28,7 @@
 
 
 #ifndef MSG_NOSIGNAL
-#define MSG_NOSIGNAL SO_NOSIGPIPE // for OS X 
+#define MSG_NOSIGNAL SO_NOSIGPIPE // for OS X
 #endif
 
 using namespace std;

--- a/shttps/SockStream.cpp
+++ b/shttps/SockStream.cpp
@@ -21,9 +21,15 @@
  * License along with Sipi.  If not, see <http://www.gnu.org/licenses/>.
  */#include "SockStream.h"
 
+#include <sys/types.h>
 #include <sys/socket.h>
 #include <string.h>
 #include <unistd.h>
+
+
+#ifndef MSG_NOSIGNAL
+#define MSG_NOSIGNAL SO_NOSIGPIPE // for OS X 
+#endif
 
 using namespace std;
 using namespace shttps;
@@ -76,7 +82,7 @@ streambuf::int_type SockStream::overflow(streambuf::int_type ch)
         size_t n = out_bufsize;
         size_t nn = 0;
         while (n > 0) {
-            ssize_t tmp_n = write(sock, out_buf + nn, n - nn);
+            ssize_t tmp_n = send(sock, out_buf + nn, n - nn, MSG_NOSIGNAL);
             if (tmp_n <= 0) {
                 return traits_type::eof();
                 // we have a problem.... Possibly a broken pipe
@@ -102,7 +108,7 @@ int SockStream::sync(void)
     size_t nn = 0;
     while (n > 0) {
         int flag = 1;
-        ssize_t tmp_n = write(sock, out_buf + nn, n - nn);
+        ssize_t tmp_n = send(sock, out_buf + nn, n - nn, MSG_NOSIGNAL);
         if (tmp_n <= 0) {
             return -1;
         }


### PR DESCRIPTION
the broken pipe bug should be fixed with this version. It required adding a own error handling to methods writing the JPEG file with libjeg. Otherwise libjpeg calls exit. In additions all exceotions in destructors have to the catched within the destructors. A exception raised in a destructor and propagted can never be catched!
