### PR TITLE
fixing cmake typo

### DIFF
--- a/ext/png/CMakeLists.txt
+++ b/ext/png/CMakeLists.txt
@@ -8,9 +8,9 @@ include(ExternalProject)
 ExternalProject_Add(
         project_png
         INSTALL_DIR ${COMMON_LOCAL}
-        URL https://sourceforge.net/projects/libpng/files/libpng16/1.6.23/libpng-1.6.23.tar.gz/download
-        DOWNLOAD_NAME libpng-latest.tar.xz
-        #URL https://sourceforge.net/projects/libpng/files/latest/download?source=files
+        #URL https://sourceforge.net/projects/libpng/files/libpng16/1.6.23/libpng-1.6.23.tar.gz/download
+        DOWNLOAD_NAME libpng-latest.tar.gz
+        URL https://sourceforge.net/projects/libpng/files/latest/download?source=files
         SOURCE_DIR ${COMMON_SRCS}/libpng-latest
         CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${COMMON_LOCAL} -DCMAKE_INSTALL_LIBDIR=${CONFIGURE_LIBDIR}
 )


### PR DESCRIPTION
request latest version, fixed typo in DOWNLOAD_NAME
the file name has to have an extension (bz2|tar|tgz|tar\\.gz|zip) otherwise cmake doesn't acknowledge it is a file name and still tries to parse the URL for a file name