### PR TITLE
Use smart pointers for some objects

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -323,7 +323,7 @@ add_executable(
         shttps/GetMimetype.cpp shttps/GetMimetype.h
         shttps/Server.cpp shttps/Server.h
         shttps/jwt.c shttps/jwt.h
-)
+        shttps/makeunique.h)
 add_dependencies(sipi icc_profiles)
 
 

--- a/include/SipiCache.h
+++ b/include/SipiCache.h
@@ -178,11 +178,11 @@ namespace Sipi {
         std::string check(const std::string &origpath_p, const std::string &canonical_p);
 
         /*!
-         * generate a new name for a cache file
+         * Creates a new cache file with a unique name.
          *
-         * \returns New name for cache file.
+         * \return the name of the file.
          */
-        std::string getNewCacheName(void);
+        std::string getNewCacheFileName(void);
 
         /*!
          * Add (or replace) a file to the cache.

--- a/include/SipiHttpServer.h
+++ b/include/SipiHttpServer.h
@@ -72,7 +72,15 @@ namespace Sipi {
         ~SipiHttpServer();
         void run();
 
-        std::pair<std::string,std::string> get_canonical_url(int img_w, int img_h, const std::string &host, const std::string &prefix, const std::string &identifier, SipiRegion &region, SipiSize &size, SipiRotation &rotation, SipiQualityFormat &quality_format);
+        std::pair<std::string,std::string> get_canonical_url(int img_w,
+                                                             int img_h,
+                                                             const std::string &host,
+                                                             const std::string &prefix,
+                                                             const std::string &identifier,
+                                                             std::shared_ptr<SipiRegion> region,
+                                                             std::shared_ptr<SipiSize> size,
+                                                             SipiRotation &rotation,
+                                                             SipiQualityFormat &quality_format);
 
 
         inline pid_t pid(void) { return _pid; }

--- a/include/SipiHttpServer.h
+++ b/include/SipiHttpServer.h
@@ -60,7 +60,7 @@ namespace Sipi {
         std::string _salsah_prefix;
         bool _prefix_as_path;
         std::string _logfile;
-        SipiCache *_cache;
+        std::shared_ptr<SipiCache> _cache;
     public:
        /*!
         * Constructor which automatically starts the server
@@ -69,7 +69,6 @@ namespace Sipi {
         * \param root_p Path to the root of directory containing the images
         */
         SipiHttpServer(int port_p, unsigned nthreads_p = 4, const std::string userid_str = "", const std::string &logfile_p = "sipi.log", const std::string &loglevel_p = "DEBUG");
-        ~SipiHttpServer();
         void run();
 
         std::pair<std::string,std::string> get_canonical_url(int img_w,
@@ -95,7 +94,7 @@ namespace Sipi {
         inline void prefix_as_path(bool prefix_as_path_p) { _prefix_as_path = prefix_as_path_p; }
 
         void cache(const std::string &cachedir_p, long long max_cachesize_p = 0, unsigned max_nfiles_p = 0, float cache_hysteresis_p = 0.1);
-        inline SipiCache *cache() { return _cache; }
+        inline std::shared_ptr<SipiCache> cache() { return _cache; }
 
     };
 

--- a/include/SipiIO.h
+++ b/include/SipiIO.h
@@ -53,7 +53,7 @@ namespace Sipi {
          * to read only half the resolution. [default: 0]
          * \param force_bps_8 Convert the file to 8 bits/sample on reading thus enforcing an 8 bit image
          */
-        virtual bool read(SipiImage *img, std::string filepath, SipiRegion *region = NULL, SipiSize *size = NULL, bool force_bps_8 = true) = 0;
+        virtual bool read(SipiImage *img, std::string filepath, std::shared_ptr<SipiRegion> region = nullptr, std::shared_ptr<SipiSize> size = nullptr, bool force_bps_8 = true) = 0;
 
        /*!
         * Get the dimension of the image

--- a/include/SipiImage.h
+++ b/include/SipiImage.h
@@ -169,7 +169,7 @@ namespace Sipi {
         friend class SipiIOJpeg;    //!< I/O class for the JPEG file format
         friend class SipiIOPng;     //!< I/O class for the PNG file format
     private:
-        static std::unordered_map<std::string,SipiIO*> io; //!< member variable holding a map of I/O class instances for the different file formats
+        static std::unordered_map<std::string, std::shared_ptr<SipiIO> > io; //!< member variable holding a map of I/O class instances for the different file formats
         byte bilinn (byte buf[], register int nx, register float x, register float y, register int c, register int n);
         word bilinn (word buf[], register int nx, register float x, register float y, register int c, register int n);
     protected:

--- a/include/SipiImage.h
+++ b/include/SipiImage.h
@@ -148,7 +148,7 @@ namespace Sipi {
             std::string errStr = rhs.to_string();
             outStream << errStr << std::endl; // TODO: remove the endl, the logging code should do it
             return outStream;
-    }
+        }
     };
 
 
@@ -172,6 +172,7 @@ namespace Sipi {
         static std::unordered_map<std::string, std::shared_ptr<SipiIO> > io; //!< member variable holding a map of I/O class instances for the different file formats
         byte bilinn (byte buf[], register int nx, register float x, register float y, register int c, register int n);
         word bilinn (word buf[], register int nx, register float x, register float y, register int c, register int n);
+        void ensure_exif();
     protected:
         int nx;         //!< Number of horizontal pixels (width)
         int ny;         //!< Number of vertical pixels (height)
@@ -180,12 +181,12 @@ namespace Sipi {
         std::vector<ExtraSamples> es; //!< meaning of extra samples
         PhotometricInterpretation photo;    //!< Image type, that is the meaning of the channels
         byte *pixels;   //!< Pointer to block of memory holding the pixels
-        SipiXmp *xmp;   //!< Pointer to instance SipiXmp class (\ref SipiXmp), or NULL
-        SipiIcc *icc;   //!< Pointer to instance of SipiIcc class (\ref SipiIcc), or NULL
-        SipiIptc *iptc; //!< Pointer to instance of SipiIptc class (\ref SipiIptc), or NULL
-        SipiExif *exif; //!< Pointer to instance of SipiExif class (\ref SipiExif), or NULL
+        std::shared_ptr<SipiXmp> xmp;   //!< Pointer to instance SipiXmp class (\ref SipiXmp), or NULL
+        std::shared_ptr<SipiIcc> icc;   //!< Pointer to instance of SipiIcc class (\ref SipiIcc), or NULL
+        std::shared_ptr<SipiIptc> iptc; //!< Pointer to instance of SipiIptc class (\ref SipiIptc), or NULL
+        std::shared_ptr<SipiExif> exif; //!< Pointer to instance of SipiExif class (\ref SipiExif), or NULL
         SipiEssentials emdata; //!< Metadata to be stored in file header
-        shttps::Connection *conobj; //!< Pointer to mongoose webserver connection data
+        shttps::Connection* conobj; //!< Pointer to HTTP connection
         SkipMetadata skip_metadata; //!< If true, all metadata is stripped off
     public:
         static std::unordered_map<std::string, std::string> mimetypes; //! format (key) to mimetype (value) conversion map
@@ -237,7 +238,7 @@ namespace Sipi {
        /*!
         * Getter for number of alpha channels
         */
-        inline int getNalpha() { return es.size(); }
+        inline unsigned long getNalpha() { return es.size(); }
 
         /*! Destructor
          *
@@ -274,7 +275,7 @@ namespace Sipi {
                     if (val > 0xffff) throw ((int) 6);
                 }
             }
-        };
+        }
 
         /*!
          * Assignment operator
@@ -305,11 +306,11 @@ namespace Sipi {
         *
         * \returns Pointer to connection data
         */
-         inline shttps::Connection *connection() { return conobj; };
+        inline shttps::Connection *connection() { return conobj; };
 
-         inline void essential_metadata(const SipiEssentials &emdata_p) { emdata = emdata_p; }
+        inline void essential_metadata(const SipiEssentials &emdata_p) { emdata = emdata_p; }
 
-         inline SipiEssentials essential_metadata(void) { return emdata; }
+        inline SipiEssentials essential_metadata(void) { return emdata; }
 
        /*!
         * Read an image from the given path
@@ -322,7 +323,7 @@ namespace Sipi {
         *
         * \throws SipiError
         */
-        void read(std::string filepath, SipiRegion *region = NULL, SipiSize *size = NULL, bool force_bps_8 = false);
+        void read(std::string filepath, std::shared_ptr<SipiRegion> region = nullptr, std::shared_ptr<SipiSize> size = nullptr, bool force_bps_8 = false);
 
        /*!
         * Read an image that is to be considered an "original image". In this case
@@ -344,7 +345,7 @@ namespace Sipi {
         *
         * \returns true, if everythin worked. False, if the checksums do not match.
         */
-        bool readOriginal(const std::string &filepath, SipiRegion *region, SipiSize *size, shttps::HashType htype = shttps::HashType::sha256);
+        bool readOriginal(const std::string &filepath, std::shared_ptr<SipiRegion> region, std::shared_ptr<SipiSize> size, shttps::HashType htype = shttps::HashType::sha256);
 
         /*!
          * Read an image that is to be considered an "original image". In this case
@@ -367,7 +368,7 @@ namespace Sipi {
          *
          * \returns true, if everythin worked. False, if the checksums do not match.
          */
-        bool readOriginal(const std::string &filepath, SipiRegion *region, SipiSize *size, const std::string &origname, shttps::HashType htype);
+        bool readOriginal(const std::string &filepath, std::shared_ptr<SipiRegion> region, std::shared_ptr<SipiSize> size, const std::string &origname, shttps::HashType htype);
 
 
        /*!
@@ -431,7 +432,7 @@ namespace Sipi {
         * \param[in] width Width of the region. If the region goes beyond the image dimensions, it's adjusted.
         * \param[in] height Height of the region. If the region goes beyond the image dimensions, it's adjusted
         */
-        bool crop(SipiRegion *region);
+        bool crop(std::shared_ptr<SipiRegion> region);
 
        /*!
         * Resize an image

--- a/include/formats/SipiIOJ2k.h
+++ b/include/formats/SipiIOJ2k.h
@@ -49,7 +49,7 @@ namespace Sipi {
         * only reads part of the data returning an image with reduces resolution.
         * If the value is 1, only half the resolution is returned. If it is 2, only one forth etc.
         */
-        bool read(SipiImage *img, std::string filepath, SipiRegion *region = NULL, SipiSize *size = NULL, bool force_bps_8 = false);
+        bool read(SipiImage *img, std::string filepath, std::shared_ptr<SipiRegion> region = nullptr, std::shared_ptr<SipiSize> size = nullptr, bool force_bps_8 = false);
 
        /*!
         * Get the dimension of the image

--- a/include/formats/SipiIOJpeg.h
+++ b/include/formats/SipiIOJpeg.h
@@ -47,7 +47,7 @@ namespace Sipi {
         * only reads part of the data returning an image with reduces resolution.
         * If the value is 1, only half the resolution is returned. If it is 2, only one forth etc.
         */
-        bool read(SipiImage *img, std::string filepath, SipiRegion *region = NULL, SipiSize *size = NULL, bool force_bps_8 = false);
+        bool read(SipiImage *img, std::string filepath, std::shared_ptr<SipiRegion> region = nullptr, std::shared_ptr<SipiSize> size = nullptr, bool force_bps_8 = false);
 
        /*!
         * Get the dimension of the image

--- a/include/formats/SipiIOOpenJ2k.h
+++ b/include/formats/SipiIOOpenJ2k.h
@@ -49,7 +49,7 @@ namespace Sipi {
          * only reads part of the data returning an image with reduces resolution.
          * If the value is 1, only half the resolution is returned. If it is 2, only one forth etc.
          */
-        bool read(SipiImage *img, std::string filepath, SipiRegion *region = NULL, SipiSize *size = NULL);
+        bool read(SipiImage *img, std::string filepath, std::shared_ptr<SipiRegion> region = nullptr, std::shared_ptr<SipiSize> size = nullptr);
 
         /*!
          * Get the dimension of the image

--- a/include/formats/SipiIOPng.h
+++ b/include/formats/SipiIOPng.h
@@ -41,7 +41,7 @@ namespace Sipi {
         * \param filepath Image file path
         * \param reduce Reducing factor. Not used reading TIFF files
         */
-        bool read(SipiImage *img, std::string filepath, SipiRegion *region = NULL, SipiSize *size = NULL, bool force_bps_8 = false);
+        bool read(SipiImage *img, std::string filepath, std::shared_ptr<SipiRegion> region = nullptr, std::shared_ptr<SipiSize> size = nullptr, bool force_bps_8 = false);
 
        /*!
         * Get the dimension of the image

--- a/include/formats/SipiIOTiff.h
+++ b/include/formats/SipiIOTiff.h
@@ -91,7 +91,7 @@ namespace Sipi {
         * \param filepath Image file path
         * \param reduce Reducing factor. Not used reading TIFF files
         */
-        bool read(SipiImage *img, std::string filepath, SipiRegion *region = NULL, SipiSize *size = NULL, bool force_bps_8 = false);
+        bool read(SipiImage *img, std::string filepath, std::shared_ptr<SipiRegion> region = nullptr, std::shared_ptr<SipiSize> size = nullptr, bool force_bps_8 = false);
 
         /*!
         * Get the dimension of the image

--- a/shttps/ChunkReader.cpp
+++ b/shttps/ChunkReader.cpp
@@ -64,13 +64,13 @@ namespace shttps {
             throw Error(__file__, __LINE__, ia.what());
         }
         if (n == 0) return 0;
-        if (*buf == NULL) {
-            if ((*buf = (char *) malloc((n + 1)*sizeof(char))) == NULL) {
+        if (*buf == nullptr) {
+            if ((*buf = (char *) malloc((n + 1)*sizeof(char))) == nullptr) {
                 throw Error(__file__, __LINE__, "malloc failed", errno);
             }
         }
         else {
-            if ((*buf = (char *) realloc(*buf, (offs + n + 1)*sizeof(char))) == NULL) {
+            if ((*buf = (char *) realloc(*buf, (offs + n + 1)*sizeof(char))) == nullptr) {
                 throw Error(__file__, __LINE__, "realloc failed", errno);
             }
         }
@@ -96,7 +96,7 @@ namespace shttps {
 
     size_t ChunkReader::readAll(char **buf) {
         size_t n, nbytes = 0;
-        *buf = NULL;
+        *buf = nullptr;
         while ((n = read_chunk(*ins, buf, nbytes)) > 0) {
             nbytes += n;
         }

--- a/shttps/Connection.cpp
+++ b/shttps/Connection.cpp
@@ -341,20 +341,20 @@ namespace shttps {
 
 
     Connection::Connection(void) {
-        _server = NULL;
+        _server = nullptr;
         _secure = false;
-        ins = NULL;
-        os = NULL;
-        cachefile = NULL;
+        ins = nullptr;
+        os = nullptr;
+        cachefile = nullptr;
         outbuf_size = 0;
         outbuf_inc = 0;
-        outbuf = NULL;
+        outbuf = nullptr;
         header_sent = false;
         _keep_alive = false;  // should be true as this is the default for HTTP/1.1, but ab makes a porblem
         _keep_alive_timeout = -1;
         _chunked_transfer_in = false;
         _chunked_transfer_out = false;
-        _content = NULL;
+        _content = nullptr;
         content_length = 0;
         _finished = false;
         _reset_connection = false;
@@ -367,13 +367,13 @@ namespace shttps {
     {
         _server = server_p;
         _secure = false;
-        cachefile = NULL;
+        cachefile = nullptr;
         header_sent = false;
         _keep_alive = false; // should be true as this is the default for HTTP/1.1, but ab makes a porblem
         _keep_alive_timeout = -1;
         _chunked_transfer_in = false;
         _chunked_transfer_out = false;
-        _content = NULL;
+        _content = nullptr;
         content_length = 0;
         _finished = false;
         _reset_connection = false;
@@ -381,13 +381,13 @@ namespace shttps {
         status(OK); // thats the default...
 
         if (outbuf_size > 0) {
-            if ((outbuf = (char *) malloc(outbuf_size)) == NULL) {
+            if ((outbuf = (char *) malloc(outbuf_size)) == nullptr) {
                 throw Error(__file__, __LINE__, "malloc failed!", errno);
             }
             outbuf_nbytes = 0;
         }
         else {
-            outbuf = NULL;
+            outbuf = nullptr;
         }
 
         string line;
@@ -478,25 +478,25 @@ namespace shttps {
                 if (content_length > 0) {
                     vector <string> content_type_opts = process_header_value(header_in["content-type"]);
                     if (content_type_opts[0] == "application/x-www-form-urlencoded") {
-                        char *bodybuf = NULL;
+                        char *bodybuf = nullptr;
                         if (_chunked_transfer_in) {
                             char *tmp;
                             ChunkReader ckrd(ins);
                             content_length = ckrd.readAll(&tmp);
-                            if ((bodybuf = (char *) malloc((content_length + 1) * sizeof(char))) == NULL) {
+                            if ((bodybuf = (char *) malloc((content_length + 1) * sizeof(char))) == nullptr) {
                                 throw Error(__file__, __LINE__, "malloc failed!", errno);
                             }
                             memcpy(_content, tmp, content_length);
                             free (tmp);
                         }
                         else {
-                            if ((bodybuf = (char *) malloc((content_length + 1) * sizeof(char))) == NULL) {
+                            if ((bodybuf = (char *) malloc((content_length + 1) * sizeof(char))) == nullptr) {
                                 throw Error(__file__, __LINE__, "malloc failed!", errno);
                             }
                             ins->read(bodybuf, content_length);
                             if (ins->fail() || ins->eof()) {
                                 free(bodybuf);
-                                bodybuf = NULL;
+                                bodybuf = nullptr;
                                 throw -1;
                             }
                         }
@@ -716,7 +716,7 @@ namespace shttps {
                             char *tmp;
                             ChunkReader ckrd(ins);
                             content_length = ckrd.readAll(&tmp);
-                            if ((_content = (char *) malloc((content_length + 1) * sizeof(char))) == NULL) {
+                            if ((_content = (char *) malloc((content_length + 1) * sizeof(char))) == nullptr) {
                                 throw Error(__file__, __LINE__, "malloc failed!", errno);
                             }
                             memcpy(_content, tmp, content_length);
@@ -724,13 +724,13 @@ namespace shttps {
                             _content[content_length] = '\0';
                         }
                         else if (content_length > 0) {
-                            if ((_content = (char *) malloc((content_length + 1) * sizeof(char))) == NULL) {
+                            if ((_content = (char *) malloc((content_length + 1) * sizeof(char))) == nullptr) {
                                 throw Error(__file__, __LINE__, "malloc failed!", errno);
                             }
                             ins->read(_content, content_length);
                             if (ins->fail() || ins->eof()) {
                                 free(_content);
-                                _content = NULL;
+                                _content = nullptr;
                                 throw -1;
                             }
                             _content[content_length] = '\0';
@@ -760,7 +760,7 @@ namespace shttps {
                         char *tmp;
                         ChunkReader ckrd(ins);
                         content_length = ckrd.readAll(&tmp);
-                        if ((_content = (char *) malloc((content_length + 1) * sizeof(char))) == NULL) {
+                        if ((_content = (char *) malloc((content_length + 1) * sizeof(char))) == nullptr) {
                             throw Error(__file__, __LINE__, "malloc failed!", errno);
                         }
                         memcpy(_content, tmp, content_length);
@@ -770,13 +770,13 @@ namespace shttps {
                     else if (content_length > 0) {
 
                         _content = (char *) malloc(content_length + 1);
-                        if (_content == NULL) {
+                        if (_content == nullptr) {
                             throw Error(__file__, __LINE__, "malloc failed!", errno);
                         }
                         ins->read(_content, content_length);
                         if (ins->fail() || ins->eof()) {
                             free(_content);
-                            _content = NULL;
+                            _content = nullptr;
                             throw -1;
                         }
                         _content[content_length] = '\0';
@@ -822,15 +822,15 @@ namespace shttps {
         catch (int i) {
             // do nothing....
         }
-        if (_content != NULL) {
+        if (_content != nullptr) {
             free(_content);
         }
-        if (outbuf != NULL) {
+        if (outbuf != nullptr) {
             free (outbuf);
         }
-        if (cachefile != NULL) {
+        if (cachefile != nullptr) {
             delete cachefile;
-            cachefile = NULL;
+            cachefile = nullptr;
         }
     }
     //=============================================================================
@@ -985,8 +985,8 @@ namespace shttps {
         if (header_sent) {
             throw Error(__file__, __LINE__, "Header already sent - cannot changed to buffered mode!");
         }
-        if (outbuf == NULL) {
-            if ((outbuf = (char *) malloc(outbuf_size)) == NULL) {
+        if (outbuf == nullptr) {
+            if ((outbuf = (char *) malloc(outbuf_size)) == nullptr) {
                 throw Error(__file__, __LINE__, "malloc failed!", errno);
             }
             outbuf_nbytes = 0;
@@ -1018,7 +1018,7 @@ namespace shttps {
     {
         cachefile->close();
         delete cachefile;
-        cachefile = NULL;
+        cachefile = nullptr;
     }
     //=============================================================================
 
@@ -1057,7 +1057,7 @@ namespace shttps {
 
     void Connection::corsHeader(const char *origin)
     {
-        if (origin == NULL) return;
+        if (origin == nullptr) return;
         header_out["Access-Control-Allow-Origin"] = origin;
         header_out["Access-Control-Allow-Credentials"] = "true";
         //header_out["Access-Control-Expose-Headers"] = "FooBar";
@@ -1082,7 +1082,7 @@ namespace shttps {
         }
         os->write((char *) buffer, n);
         if (os->eof() || os->fail()) throw -1;
-        if (cachefile != NULL) cachefile->write((char *) buffer, n);
+        if (cachefile != nullptr) cachefile->write((char *) buffer, n);
     }
     //=============================================================================
 
@@ -1091,7 +1091,7 @@ namespace shttps {
     {
         if (_finished) throw Error(__file__, __LINE__, "Sending data already terminated!");
 
-        if (outbuf != NULL) {
+        if (outbuf != nullptr) {
             //
             // we have a buffer -> we add the data to the buffer
             //
@@ -1111,7 +1111,7 @@ namespace shttps {
                     if (os->eof() || os->fail()) throw -1;
                     os->write((char *) buffer, n);
                     if (os->eof() || os->fail()) throw -1;
-                    if (cachefile != NULL) cachefile->write((char *) buffer, n);
+                    if (cachefile != nullptr) cachefile->write((char *) buffer, n);
                     *os << "\r\n";
                     if (os->eof() || os->fail()) throw -1;
                     os->flush();
@@ -1124,7 +1124,7 @@ namespace shttps {
                     send_header(n); // sends content length if not buffer nor chunked
                     os->write((char *) buffer, n);
                     if (os->eof() || os->fail()) throw -1;
-                    if (cachefile != NULL) cachefile->write((char *) buffer, n);
+                    if (cachefile != nullptr) cachefile->write((char *) buffer, n);
                     os->flush();
                     if (os->eof() || os->fail()) throw -1;
                     _finished = true; // no more data can be sent
@@ -1139,7 +1139,7 @@ namespace shttps {
                     if (os->eof() || os->fail()) throw -1;
                     os->write((char *) buffer, n);
                     if (os->eof() || os->fail()) throw -1;
-                    if (cachefile != NULL) cachefile->write((char *) buffer, n);
+                    if (cachefile != nullptr) cachefile->write((char *) buffer, n);
                     *os << "\r\n";
                     if (os->eof() || os->fail()) throw -1;
                     os->flush();
@@ -1161,7 +1161,7 @@ namespace shttps {
     {
         if (_finished) throw Error(__file__, __LINE__, "Sending data already terminated!");
 
-        if (outbuf != NULL) {
+        if (outbuf != nullptr) {
             //
             // we have a buffer -> we add the data to the buffer
             //
@@ -1175,7 +1175,7 @@ namespace shttps {
             if (!header_sent) {
                 send_header(); // sends content length if nor buffer nor chunked
             }
-            if (outbuf != NULL) {
+            if (outbuf != nullptr) {
                 //
                 // we use the buffer -> send buffer as chunk
                 //
@@ -1183,7 +1183,7 @@ namespace shttps {
                 if (os->eof() || os->fail()) throw -1;
                 os->write((char *) outbuf, outbuf_nbytes);
                 if (os->eof() || os->fail()) throw -1;
-                if (cachefile != NULL) cachefile->write((char *) outbuf, outbuf_nbytes);
+                if (cachefile != nullptr) cachefile->write((char *) outbuf, outbuf_nbytes);
                 outbuf_nbytes = 0;
             }
             else {
@@ -1194,7 +1194,7 @@ namespace shttps {
                 if (os->eof() || os->fail()) throw -1;
                 os->write((char *) buffer, n);
                 if (os->eof() || os->fail()) throw -1;
-                if (cachefile != NULL) cachefile->write((char *) buffer, n);
+                if (cachefile != nullptr) cachefile->write((char *) buffer, n);
             }
             *os << "\r\n";
             if (os->eof() || os->fail()) throw -1;
@@ -1205,7 +1205,7 @@ namespace shttps {
             //
             // we don't use chunks, so we *need* the Content-Length header!
             //
-            if ((outbuf != NULL) && (outbuf_nbytes > 0)) {
+            if ((outbuf != nullptr) && (outbuf_nbytes > 0)) {
                 //
                 // we use the buffer, the header *must* contain the Content-Length header!
                 // then we send the data in the buffer
@@ -1218,7 +1218,7 @@ namespace shttps {
                 }
                 os->write((char *) buffer, n);
                 if (os->eof() || os->fail()) throw -1;
-                if (cachefile != NULL) cachefile->write((char *) buffer, n);
+                if (cachefile != nullptr) cachefile->write((char *) buffer, n);
             }
             else {
                 //
@@ -1232,7 +1232,7 @@ namespace shttps {
                 }
                 os->write((char *) buffer, n);
                 if (os->eof() || os->fail()) throw -1;
-                if (cachefile != NULL) cachefile->write((char *) buffer, n);
+                if (cachefile != nullptr) cachefile->write((char *) buffer, n);
                 outbuf_nbytes = 0;
             }
             os->flush();
@@ -1262,7 +1262,7 @@ namespace shttps {
         size_t orig_fsize;
 
         FILE *infile = fopen(path.c_str(), "rb");
-        if (infile == NULL) {
+        if (infile == nullptr) {
             throw Error(__file__, __LINE__, "File not readable!");
         }
 
@@ -1288,7 +1288,7 @@ namespace shttps {
             fsize -= (orig_fsize - to);
         }
 
-        if (outbuf != NULL) {
+        if (outbuf != nullptr) {
             char buf[bufsize];
             size_t n;
             while ((n = fread(buf, sizeof(char), bufsize, infile)) > 0) {
@@ -1341,14 +1341,14 @@ namespace shttps {
             if (_finished) throw Error(__file__, __LINE__, "Sending data already terminated!");
             send_header(); // sends content length if not buffer nor chunked
         }
-        if ((outbuf != NULL) && (outbuf_nbytes > 0)) {
+        if ((outbuf != nullptr) && (outbuf_nbytes > 0)) {
             if (_finished) throw Error(__file__, __LINE__, "Sending data already terminated!");
             if (_chunked_transfer_out) {
                 *os << std::hex << outbuf_nbytes << "\r\n";
                 if (os->eof() || os->fail()) throw -1;
                 os->write((char *) outbuf, outbuf_nbytes);
                 if (os->eof() || os->fail()) throw -1;
-                if (cachefile != NULL) cachefile->write((char *) outbuf, outbuf_nbytes);
+                if (cachefile != nullptr) cachefile->write((char *) outbuf, outbuf_nbytes);
                 *os << "\r\n";
                 if (os->eof() || os->fail()) throw -1;
                 os->flush();
@@ -1357,7 +1357,7 @@ namespace shttps {
             else {
                 os->write((char *) outbuf, outbuf_nbytes);
                 if (os->eof() || os->fail()) throw -1;
-                if (cachefile != NULL) cachefile->write((char *) outbuf, outbuf_nbytes);
+                if (cachefile != nullptr) cachefile->write((char *) outbuf, outbuf_nbytes);
                 os->flush();
                 if (os->eof() || os->fail()) throw -1;
                 _finished = true;
@@ -1409,7 +1409,7 @@ namespace shttps {
         if (outbuf_nbytes + n > outbuf_size) {
             size_t incsize = outbuf_size + ((n + outbuf_inc - 1) / outbuf_inc)*outbuf_inc;
             char *tmpbuf;
-            if ((tmpbuf = (char *) realloc(outbuf, incsize)) == NULL) {
+            if ((tmpbuf = (char *) realloc(outbuf, incsize)) == nullptr) {
                 throw Error(__file__, __LINE__, "realloc failed!", errno);
             }
             outbuf = tmpbuf;
@@ -1438,7 +1438,7 @@ namespace shttps {
             if (os->eof() || os->fail()) throw -1;
         }
         else {
-            if ((outbuf != NULL) && (outbuf_nbytes > 0)) {
+            if ((outbuf != nullptr) && (outbuf_nbytes > 0)) {
                 *os << "Content-Length: " << outbuf_nbytes << "\r\n\r\n";
                 if (os->eof() || os->fail()) throw -1;
             }

--- a/shttps/Connection.cpp
+++ b/shttps/Connection.cpp
@@ -482,7 +482,7 @@ namespace shttps {
                                 throw Error(__file__, __LINE__, "malloc failed!", errno);
                             }
                             memcpy(_content, chunk_buf, content_length);
-                            free (chunk_buf);
+                            free(chunk_buf);
                         }
                         else {
                             if ((bodybuf = (char *) malloc((content_length + 1) * sizeof(char))) == nullptr) {

--- a/shttps/Connection.cpp
+++ b/shttps/Connection.cpp
@@ -475,9 +475,9 @@ namespace shttps {
                     if (content_type_opts[0] == "application/x-www-form-urlencoded") {
                         char *bodybuf = nullptr;
                         if (_chunked_transfer_in) {
-                            char *tmp;
+                            char *tmp; // TODO: Why don't we use bodybuf here?
                             ChunkReader ckrd(ins);
-                            content_length = ckrd.readAll(&tmp);
+                            content_length = ckrd.readAll(&tmp); // TODO: No memory has been allocated for tmp, is that OK?
                             if ((bodybuf = (char *) malloc((content_length + 1) * sizeof(char))) == nullptr) {
                                 throw Error(__file__, __LINE__, "malloc failed!", errno);
                             }

--- a/shttps/Connection.cpp
+++ b/shttps/Connection.cpp
@@ -69,7 +69,7 @@ namespace shttps {
     //=========================================================================
 
     // trim from both ends
-    static inline std::string &trim(std::string &s) {
+    static inline std::string trim(std::string &s) {
         return ltrim(rtrim(s));
     }
     //=========================================================================
@@ -286,12 +286,7 @@ namespace shttps {
                     if (opts.count("keep-alive") == 1) {
                         _keep_alive = true;
                     }
-                    if (opts.count("close") == 1) {
-                        _keep_alive = false;
-                    }
-                    else {
-                        _keep_alive = true; // keep_alive is the default with HTTP/1.1
-                    }
+                    _keep_alive = opts.count("close") != 1;
                     if (opts.count("upgrade") == 1) {
                         // upgrade connection, e.g. to websockets...
                     }
@@ -307,7 +302,7 @@ namespace shttps {
                     }
                 }
                 else if (name == "content-length") {
-                    content_length = stoi(value);
+                    content_length = static_cast<size_t>(stoi(value));
                 }
                 else if (name == "transfer-encoding") {
                     if (value == "chunked") {

--- a/shttps/Connection.cpp
+++ b/shttps/Connection.cpp
@@ -475,14 +475,14 @@ namespace shttps {
                     if (content_type_opts[0] == "application/x-www-form-urlencoded") {
                         char *bodybuf = nullptr;
                         if (_chunked_transfer_in) {
-                            char *tmp; // TODO: Why don't we use bodybuf here?
+                            char *chunk_buf;
                             ChunkReader ckrd(ins);
-                            content_length = ckrd.readAll(&tmp); // TODO: No memory has been allocated for tmp, is that OK?
+                            content_length = ckrd.readAll(&chunk_buf);
                             if ((bodybuf = (char *) malloc((content_length + 1) * sizeof(char))) == nullptr) {
                                 throw Error(__file__, __LINE__, "malloc failed!", errno);
                             }
-                            memcpy(_content, tmp, content_length);
-                            free (tmp);
+                            memcpy(_content, chunk_buf, content_length);
+                            free (chunk_buf);
                         }
                         else {
                             if ((bodybuf = (char *) malloc((content_length + 1) * sizeof(char))) == nullptr) {

--- a/shttps/Connection.cpp
+++ b/shttps/Connection.cpp
@@ -627,13 +627,13 @@ namespace shttps {
                                     char *writable = new char[tmpname.size() + 1];
                                     std::copy(tmpname.begin(), tmpname.end(), writable);
                                     writable[tmpname.size()] = '\0'; // don't forget the terminating 0
+                                    int fd = mkstemp(writable);
+                                    delete[] writable;
 
-                                    int fd;
-                                    if ((fd = mkstemp(writable)) == -1) {
+                                    if (fd == -1) {
                                         throw Error(__file__, __LINE__, "Could not create temporary filename!");
                                     }
                                     tmpname = string(writable);
-                                    delete[] writable;
                                     close(fd); // here we close the file created by mkstemp
 
                                     ofstream outf(tmpname, ofstream::out | ofstream::trunc | ofstream::binary);

--- a/shttps/Connection.h
+++ b/shttps/Connection.h
@@ -668,7 +668,7 @@ namespace shttps {
         */
         void setBuffer(size_t buf_size = 8912, size_t buf_inc = 8912);
 
-        inline bool isBuffered(void) {return ( outbuf != NULL); }
+        inline bool isBuffered(void) { return ( outbuf != nullptr); }
        /*!
         * Set the transfer mode for the response to chunked
         */

--- a/shttps/Connection.h
+++ b/shttps/Connection.h
@@ -313,7 +313,7 @@ namespace shttps {
         bool _chunked_transfer_out; //!< output data is sent in chunks
         bool _finished;             //!< Transfer of response data finished
         char *_content;             //!< Content if content-type is "text/plain", "application/json" etc.
-        unsigned content_length;    //!< length of body in octets (used if not chunked transfer)
+        size_t content_length;    //!< length of body in octets (used if not chunked transfer)
         std::string _content_type;   //!< Content-type (mime type of content)
         std::ofstream *cachefile;   //!< pointer to cache file
         char *outbuf;               //!< If not NULL, pointer to the output buffer (buffered output used)

--- a/shttps/GetMimetype.cpp
+++ b/shttps/GetMimetype.cpp
@@ -25,13 +25,11 @@
 
 #include "magic.h"
 
-using namespace std;
-
 static const char __file__[] = __FILE__;
 
 namespace shttps {
 
-    pair<string,string> GetMimetype::getMimetype(const string &fpath)
+    std::pair<std::string, std::string> GetMimetype::getMimetype(const std::string &fpath)
     {
         magic_t handle;
         if ((handle = magic_open(MAGIC_MIME | MAGIC_PRESERVE_ATIME)) == nullptr) {
@@ -43,20 +41,20 @@ namespace shttps {
         }
         const char *result = magic_file(handle, fpath.c_str());
 
-        string mimestr = result;
+        std::string mimestr = result;
 
-        string mimetype;
-        string charset;
+        std::string mimetype;
+        std::string charset;
 
         size_t pos = mimestr.find(';');
-        if (pos != string::npos) {
+        if (pos != std::string::npos) {
             mimetype = mimestr.substr(0, pos);
             charset = mimestr.substr(pos + 1);
         }
         else {
             mimetype = mimestr;
         }
-        return make_pair(mimetype, charset);
+        return std::make_pair(mimetype, charset);
     }
 
 }

--- a/shttps/GetMimetype.cpp
+++ b/shttps/GetMimetype.cpp
@@ -34,11 +34,11 @@ namespace shttps {
     pair<string,string> GetMimetype::getMimetype(const string &fpath)
     {
         magic_t handle;
-        if ((handle = magic_open(MAGIC_MIME | MAGIC_PRESERVE_ATIME)) == NULL) {
+        if ((handle = magic_open(MAGIC_MIME | MAGIC_PRESERVE_ATIME)) == nullptr) {
             throw Error(__file__, __LINE__, magic_error(handle));
         }
 
-        if (magic_load(handle, NULL) != 0) {
+        if (magic_load(handle, nullptr) != 0) {
             throw Error(__file__, __LINE__, magic_error(handle));
         }
         const char *result = magic_file(handle, fpath.c_str());

--- a/shttps/Hash.cpp
+++ b/shttps/Hash.cpp
@@ -42,33 +42,33 @@ namespace shttps {
 
     Hash::Hash(HashType type) {
         context = EVP_MD_CTX_create();
-        if (context == NULL) {
+        if (context == nullptr) {
             throw Sipi::SipiError(__file__, __LINE__, "EVP_MD_CTX_create failed!");
         }
         int status;
         switch (type) {
             case none: {
-                status = EVP_DigestInit_ex(context, EVP_md5(), NULL);
+                status = EVP_DigestInit_ex(context, EVP_md5(), nullptr);
                 break;
             }
             case md5: {
-                status = EVP_DigestInit_ex(context, EVP_md5(), NULL);
+                status = EVP_DigestInit_ex(context, EVP_md5(), nullptr);
                 break;
             }
             case sha1: {
-                status = EVP_DigestInit_ex(context, EVP_sha1(), NULL);
+                status = EVP_DigestInit_ex(context, EVP_sha1(), nullptr);
                 break;
             }
             case sha256: {
-                status = EVP_DigestInit_ex(context, EVP_sha256(), NULL);
+                status = EVP_DigestInit_ex(context, EVP_sha256(), nullptr);
                 break;
             }
             case sha384: {
-                status = EVP_DigestInit_ex(context, EVP_sha384(), NULL);
+                status = EVP_DigestInit_ex(context, EVP_sha384(), nullptr);
                 break;
             }
             case sha512: {
-                status = EVP_DigestInit_ex(context, EVP_sha512(), NULL);
+                status = EVP_DigestInit_ex(context, EVP_sha512(), nullptr);
                 break;
             }
         }

--- a/shttps/LuaServer.cpp
+++ b/shttps/LuaServer.cpp
@@ -1442,7 +1442,7 @@ namespace shttps {
             lua_pushstring(L, key); // index
             switch(json_typeof(value)) {
                 case JSON_NULL: {
-                    lua_pushnil(L); // ToDo: we should create a custom Lua object named nullptr!
+                    lua_pushnil(L); // ToDo: we should create a custom Lua object named NULL!
                     break;
                 }
                 case JSON_FALSE: {
@@ -1493,7 +1493,7 @@ namespace shttps {
             lua_pushinteger(L, index);
             switch(json_typeof(value)) {
                 case JSON_NULL: {
-                    lua_pushnil(L); // ToDo: we should create a custom Lua object named nullptr!
+                    lua_pushnil(L); // ToDo: we should create a custom Lua object named NULL!
                     break;
                 }
                 case JSON_FALSE: {

--- a/shttps/LuaServer.cpp
+++ b/shttps/LuaServer.cpp
@@ -208,7 +208,7 @@ namespace shttps {
      * Instantiates a Lua server
      */
     LuaServer::LuaServer() {
-        if ((L = luaL_newstate()) == NULL) {
+        if ((L = luaL_newstate()) == nullptr) {
             throw new Error(__file__, __LINE__, "Couldn't start lua interpreter");
         }
         lua_atpanic(L, dont_panic);
@@ -220,7 +220,7 @@ namespace shttps {
      * Instantiates a Lua server
      */
     LuaServer::LuaServer(Connection &conn) {
-        if ((L = luaL_newstate()) == NULL) {
+        if ((L = luaL_newstate()) == nullptr) {
             throw new Error(__file__, __LINE__, "Couldn't start lua interpreter");
         }
         lua_atpanic(L, dont_panic);
@@ -235,7 +235,7 @@ namespace shttps {
      * \param
      */
     LuaServer::LuaServer(const std::string &luafile, bool iscode) {
-        if ((L = luaL_newstate()) == NULL) {
+        if ((L = luaL_newstate()) == nullptr) {
             throw new Error(__file__, __LINE__, "Couldn't start lua interpreter");
         }
         lua_atpanic(L, dont_panic);
@@ -266,7 +266,7 @@ namespace shttps {
      * \param[in] luafile A file containing a Lua script or a Lua code chunk
      */
     LuaServer::LuaServer(Connection &conn, const std::string &luafile, bool iscode) {
-        if ((L = luaL_newstate()) == NULL) {
+        if ((L = luaL_newstate()) == nullptr) {
             throw new Error(__file__, __LINE__, "Couldn't start lua interpreter");
         }
 
@@ -660,8 +660,8 @@ namespace shttps {
      * LUA: curdir = server.fs.getcwd()
      */
     static int lua_fs_getcwd(lua_State *L) {
-        char *dirname = getcwd(NULL, 0);
-        if (dirname != NULL) {
+        char *dirname = getcwd(nullptr, 0);
+        if (dirname != nullptr) {
             lua_pushboolean(L, true);
             lua_pushstring(L, dirname);
         }
@@ -696,8 +696,8 @@ namespace shttps {
         const char *dirname = lua_tostring(L, 1);
         lua_settop(L, 0); // clear stack
 
-        char *olddirname = getcwd(NULL, 0);
-        if (olddirname == NULL) {
+        char *olddirname = getcwd(nullptr, 0);
+        if (olddirname == nullptr) {
             lua_pushboolean(L, false);
             lua_pushstring(L, strerror(errno));
             return 2;
@@ -886,7 +886,7 @@ namespace shttps {
 
         for (int i = 1; i <= top; i++) {
             const char *str = lua_tostring(L, i);
-            if (str != NULL) {
+            if (str != nullptr) {
                 try {
                     conn->send(str, strlen(str));
                 }
@@ -1050,7 +1050,7 @@ namespace shttps {
 
             _conn = curl_easy_init();
 
-            if (_conn == NULL) {
+            if (_conn == nullptr) {
                 throw HttpError(__LINE__, "Failed to create libcurl connection");
             }
 
@@ -1083,7 +1083,7 @@ namespace shttps {
 
                 // Set the HTTP request headers.
 
-                struct curl_slist *chunk = NULL;
+                struct curl_slist *chunk = nullptr;
 
                 for (const auto& header : requestHeaders) {
                     std::string headerStr = header.first + ": " + header.second;
@@ -1280,9 +1280,9 @@ namespace shttps {
 
     static json_t *subtable(lua_State *L, int index) {
         std::string table_error("server.table_to_json(table): datatype inconsistency");
-        json_t *tableobj = NULL;
-        json_t *arrayobj = NULL;
-        json_t *tmp_luanumber = NULL;
+        json_t *tableobj = nullptr;
+        json_t *arrayobj = nullptr;
+        json_t *tmp_luanumber = nullptr;
         const char *skey;
         lua_pushnil(L);  /* first key */
         while (lua_next(L, index) != 0) {
@@ -1291,19 +1291,19 @@ namespace shttps {
             if (lua_type(L, index + 1) == LUA_TSTRING) {
                 // we have a string as key
                 skey = lua_tostring(L, index + 1);
-                if (arrayobj != NULL) {
+                if (arrayobj != nullptr) {
                     throw std::string("'server.table_to_json(table)': Cannot mix int and strings as key");
                 }
-                if (tableobj == NULL) {
+                if (tableobj == nullptr) {
                     tableobj = json_object();
                 }
             }
             else if (lua_type(L, index + 1) == LUA_TNUMBER) {
                 (void) lua_tointeger(L, index + 1);
-                if (tableobj != NULL) {
+                if (tableobj != nullptr) {
                     throw std::string("'server.table_to_json(table)': Cannot mix int and strings as key");
                 }
-                if (arrayobj == NULL) {
+                if (arrayobj == nullptr) {
                     arrayobj = json_array();
                 }
             }
@@ -1330,10 +1330,10 @@ namespace shttps {
                     tmp_luanumber = json_real(val);
                 }
 
-                if (tableobj != NULL) {
+                if (tableobj != nullptr) {
                     json_object_set_new(tableobj, skey, tmp_luanumber);
                 }
-                else if (arrayobj != NULL) {
+                else if (arrayobj != nullptr) {
                     json_array_append_new(arrayobj, tmp_luanumber);
                 }
                 else {
@@ -1343,10 +1343,10 @@ namespace shttps {
             else if (lua_type(L, index + 2) == LUA_TSTRING) {
                 // a string value
                 const char *val = lua_tostring(L, index + 2);
-                if (tableobj != NULL) {
+                if (tableobj != nullptr) {
                     json_object_set_new(tableobj, skey, json_string(val));
                 }
-                else if (arrayobj != NULL) {
+                else if (arrayobj != nullptr) {
                     json_array_append_new(arrayobj, json_string(val));
                 }
                 else {
@@ -1356,10 +1356,10 @@ namespace shttps {
             else if (lua_type(L, index + 2) == LUA_TBOOLEAN) {
                 // a boolean value
                 bool val = lua_toboolean(L, index + 2);
-                if (tableobj != NULL) {
+                if (tableobj != nullptr) {
                     json_object_set_new(tableobj, skey, json_boolean(val));
                 }
-                else if (arrayobj != NULL) {
+                else if (arrayobj != nullptr) {
                     json_array_append_new(arrayobj, json_boolean(val));
                 }
                 else {
@@ -1367,10 +1367,10 @@ namespace shttps {
                 }
             }
             else if (lua_type(L, index + 2) == LUA_TTABLE) {
-                if (tableobj != NULL) {
+                if (tableobj != nullptr) {
                     json_object_set_new(tableobj, skey, subtable(L, index + 2));
                 }
-                else if (arrayobj != NULL) {
+                else if (arrayobj != nullptr) {
                     json_array_append_new(arrayobj, subtable(L, index + 2));
                 }
                 else {
@@ -1382,7 +1382,7 @@ namespace shttps {
             }
             lua_pop(L, 1);
         }
-        return tableobj != NULL ? tableobj : (arrayobj != NULL ? arrayobj : NULL);
+        return tableobj != nullptr ? tableobj : (arrayobj != nullptr ? arrayobj : nullptr);
     }
     //=========================================================================
 
@@ -1405,7 +1405,7 @@ namespace shttps {
             return 2;
         }
 
-        json_t *root = NULL;
+        json_t *root = nullptr;
         try {
             root = subtable(L, 1);
         }
@@ -1442,7 +1442,7 @@ namespace shttps {
             lua_pushstring(L, key); // index
             switch(json_typeof(value)) {
                 case JSON_NULL: {
-                    lua_pushnil(L); // ToDo: we should create a custom Lua object named NULL!
+                    lua_pushnil(L); // ToDo: we should create a custom Lua object named nullptr!
                     break;
                 }
                 case JSON_FALSE: {
@@ -1493,7 +1493,7 @@ namespace shttps {
             lua_pushinteger(L, index);
             switch(json_typeof(value)) {
                 case JSON_NULL: {
-                    lua_pushnil(L); // ToDo: we should create a custom Lua object named NULL!
+                    lua_pushnil(L); // ToDo: we should create a custom Lua object named nullptr!
                     break;
                 }
                 case JSON_FALSE: {
@@ -1557,7 +1557,7 @@ namespace shttps {
 
         json_t *jsonobj = json_loads(jsonstr, JSON_REJECT_DUPLICATES, &jsonerror);
 
-        if (jsonobj == NULL) {
+        if (jsonobj == nullptr) {
             lua_pushboolean(L, false);
             std::stringstream ss;
             ss << "'server.json_to_table(jsonstr)': Error parsing JSON: " << jsonerror.text << std::endl;
@@ -1949,7 +1949,7 @@ namespace shttps {
             return 2;
         }
         char *tokendata;
-        if ((tokendata = jwt_dump_str(jwt, false)) == NULL) {
+        if ((tokendata = jwt_dump_str(jwt, false)) == nullptr) {
             lua_pushboolean(L, false);
             lua_pushstring(L, "'server.decode_jwt(token)': Error in decoding token! (2)");
             return 2;
@@ -2513,7 +2513,7 @@ namespace shttps {
                 {"method", LUA_TSTRING},
                 {"route",  LUA_TSTRING},
                 {"script", LUA_TSTRING},
-                {NULL,     0}
+                {nullptr,  0}
         };
 
         std::vector<LuaRoute> routes;
@@ -2531,8 +2531,8 @@ namespace shttps {
             luaL_checktype(L, -1, LUA_TTABLE);
             int field_index;
             LuaRoute route;
-            for (field_index = 0; (fields[field_index].name != NULL
-                                   && fields[field_index].name != NULL); field_index++) {
+            for (field_index = 0; (fields[field_index].name != nullptr
+                                   && fields[field_index].name != nullptr); field_index++) {
                 lua_getfield(L, -1, fields[field_index].name);
                 luaL_checktype(L, -1, fields[field_index].type);
 
@@ -2590,7 +2590,7 @@ namespace shttps {
 
     int LuaServer::executeChunk(const std::string &luastr) {
         if (luaL_dostring(L, luastr.c_str()) != LUA_OK) {
-            const char *errorMsg = NULL;
+            const char *errorMsg = nullptr;
             if (lua_gettop(L) > 0) {
                 errorMsg = lua_tostring(L, 1);
                 lua_pop(L, 1);

--- a/shttps/LuaSqlite.cpp
+++ b/shttps/LuaSqlite.cpp
@@ -57,7 +57,7 @@ namespace shttps {
 
     static Sqlite *toSqlite(lua_State *L, int index) {
         Sqlite *db = (Sqlite *) lua_touserdata(L, index);
-        if (db == NULL) {
+        if (db == nullptr) {
             lua_pushstring(L, "Type error");
             lua_error(L);
         }
@@ -69,7 +69,7 @@ namespace shttps {
         Sqlite *db;
         luaL_checktype(L, index, LUA_TUSERDATA);
         db = (Sqlite *) luaL_checkudata(L, index, LUASQLITE);
-        if (db == NULL) {
+        if (db == nullptr) {
             lua_pushstring(L, "Type error");
             lua_error(L);
         }
@@ -90,9 +90,9 @@ namespace shttps {
     //
     static int Sqlite_gc(lua_State *L) {
         Sqlite *db = toSqlite(L, 1);
-        if (db->sqlite_handle != NULL) {
+        if (db->sqlite_handle != nullptr) {
             sqlite3_close_v2(db->sqlite_handle);
-            db->sqlite_handle = NULL;
+            db->sqlite_handle = nullptr;
         }
         delete db->dbname;
         return 0;
@@ -110,7 +110,7 @@ namespace shttps {
 
     static Stmt *toStmt(lua_State *L, int index) {
         Stmt *stmt = (Stmt *) lua_touserdata(L, index);
-        if (stmt == NULL) {
+        if (stmt == nullptr) {
             lua_pushstring(L, "Type error");
             lua_error(L);
         }
@@ -122,7 +122,7 @@ namespace shttps {
         luaL_checktype(L, index, LUA_TUSERDATA);
 
         Stmt *stmt = (Stmt *) luaL_checkudata(L, index, LUASQLSTMT);
-        if (stmt == NULL) {
+        if (stmt == nullptr) {
             lua_pushstring(L, "Type error");
             lua_error(L);
         }
@@ -143,7 +143,7 @@ namespace shttps {
     //
     static int Stmt_gc(lua_State *L) {
         Stmt *stmt = toStmt(L, 1);
-        if (stmt->stmt_handle != NULL) sqlite3_finalize(stmt->stmt_handle);
+        if (stmt->stmt_handle != nullptr) sqlite3_finalize(stmt->stmt_handle);
         return 0;
     }
     //=========================================================================
@@ -173,11 +173,11 @@ namespace shttps {
             return lua_error(L);
         }
         Sqlite *db = checkSqlite(L, 1);
-        if (db == NULL) {
+        if (db == nullptr) {
             lua_pushstring(L, "Couldn't connect to database!");
             return lua_error(L);
         }
-        const char *sql = NULL;
+        const char *sql = nullptr;
         if (lua_isstring(L, 2)) {
             sql = lua_tostring(L, 2);
         }
@@ -187,7 +187,7 @@ namespace shttps {
             return 0;
         }
         sqlite3_stmt *stmt_handle;
-        int status = sqlite3_prepare_v2(db->sqlite_handle, sql, strlen(sql), &stmt_handle, NULL);
+        int status = sqlite3_prepare_v2(db->sqlite_handle, sql, strlen(sql), &stmt_handle, nullptr);
         if (status !=  SQLITE_OK) {
             lua_pushstring(L, sqlite3_errmsg(db->sqlite_handle));
             return lua_error(L);
@@ -203,9 +203,9 @@ namespace shttps {
 
     static int Sqlite_destroy(lua_State *L) {
         Sqlite *db = toSqlite(L, 1);
-        if (db->sqlite_handle != NULL) {
+        if (db->sqlite_handle != nullptr) {
             sqlite3_close_v2(db->sqlite_handle);
-            db->sqlite_handle = NULL;
+            db->sqlite_handle = nullptr;
         }
         return 0;
     }
@@ -246,7 +246,7 @@ namespace shttps {
         }
 
         Stmt *stmt = checkStmt(L, 1);
-        if (stmt == NULL) {
+        if (stmt == nullptr) {
             lua_pushstring(L, "Stmt_next: Invalid prepared statment!");
             return lua_error(L);
         }
@@ -357,10 +357,10 @@ namespace shttps {
 
     static int Stmt_destroy(lua_State *L) {
         Stmt *stmt = toStmt(L, 1);
-        if (stmt->stmt_handle != NULL) {
+        if (stmt->stmt_handle != nullptr) {
             sqlite3_finalize(stmt->stmt_handle);
-            stmt->stmt_handle = NULL;
-            stmt->sqlite_handle = NULL;
+            stmt->stmt_handle = nullptr;
+            stmt->sqlite_handle = nullptr;
         }
         return 0;
     }
@@ -411,7 +411,7 @@ namespace shttps {
         flags |=  SQLITE_OPEN_NOMUTEX;
 
         sqlite3 *handle;
-        int status = sqlite3_open_v2(dbpath, &handle, flags, NULL);
+        int status = sqlite3_open_v2(dbpath, &handle, flags, nullptr);
         if (status !=  SQLITE_OK) {
             lua_pushstring(L, sqlite3_errmsg(handle));
             return lua_error(L);

--- a/shttps/LuaSqlite.cpp
+++ b/shttps/LuaSqlite.cpp
@@ -33,8 +33,6 @@
 
 #include "SipiHttpServer.h"
 
-using namespace std;
-
 namespace shttps {
 
 
@@ -56,7 +54,7 @@ namespace shttps {
 
 
     static Sqlite *toSqlite(lua_State *L, int index) {
-        Sqlite *db = (Sqlite *) lua_touserdata(L, index);
+        Sqlite *db = static_cast<Sqlite *>(lua_touserdata(L, index));
         if (db == nullptr) {
             lua_pushstring(L, "Type error");
             lua_error(L);
@@ -78,7 +76,7 @@ namespace shttps {
     //=========================================================================
 
     static Sqlite *pushSqlite(lua_State *L) {
-        Sqlite *db = (Sqlite *) lua_newuserdata(L, sizeof(Sqlite));
+        Sqlite *db = static_cast<Sqlite *>(lua_newuserdata(L, sizeof(Sqlite)));
         luaL_getmetatable(L, LUASQLITE);
         lua_setmetatable(L, -2);
         return db;
@@ -397,7 +395,7 @@ namespace shttps {
 
         int flags = SQLITE_OPEN_READWRITE;
         if ((top >= 2) && (lua_isstring(L,2))) {
-            string flagstr = lua_tostring(L, 1);
+            std::string flagstr = lua_tostring(L, 1);
             if (flagstr == "RO") {
                 flags = SQLITE_OPEN_READONLY;
             }

--- a/shttps/Server.cpp
+++ b/shttps/Server.cpp
@@ -19,9 +19,8 @@
  * See the GNU Affero General Public License for more details.
  * You should have received a copy of the GNU Affero General Public
  * License along with Sipi.  If not, see <http://www.gnu.org/licenses/>.
- *//*!
- * \file Connection.cpp
  */
+
 #include <algorithm>
 #include <functional>
 #include <cctype>
@@ -87,10 +86,10 @@ namespace shttps {
 
     /*!
      * Starts a thread just to catch all signals sent to the server process.
-     * If it receives SIGINT, tells the server to stop.
+     * If it receives SIGINT or SIGTERM, tells the server to stop.
      */
-    static void* sig_thread(void *arg) {
-        Server* serverptr = static_cast<Server*>(arg);
+    static void *sig_thread(void *arg) {
+        Server *serverptr = static_cast<Server *>(arg);
         sigset_t set;
         sigemptyset(&set);
         sigaddset(&set, SIGPIPE);
@@ -685,7 +684,7 @@ namespace shttps {
      * @return NULL.
      */
     static void *process_request(void *arg) {
-        TData *tdata = static_cast<TData*>(arg);
+        TData *tdata = static_cast<TData *>(arg);
         pthread_t my_tid = pthread_self();
 
         //

--- a/shttps/Server.cpp
+++ b/shttps/Server.cpp
@@ -101,7 +101,7 @@ namespace shttps {
         while (true) {
             if ((sigwait(&set, &sig)) != 0) {
                 signal_result = -1;
-                return NULL;
+                return nullptr;
             }
 
             signal_result = sig;
@@ -111,7 +111,7 @@ namespace shttps {
             // SIGPIPE.
             if (sig == SIGINT || sig == SIGTERM) {
                 serverptr->stop();
-                return NULL;
+                return nullptr;
             }
         }
     }
@@ -274,7 +274,7 @@ namespace shttps {
 
         std::string docroot;
         std::string route;
-        if (hd == NULL) {
+        if (hd == nullptr) {
             docroot = ".";
             route = "/";
         }
@@ -451,7 +451,7 @@ namespace shttps {
         //
         semname = "shttps";
         semname += std::to_string(port);
-        _user_data = NULL;
+        _user_data = nullptr;
         running = false;
         _keep_alive_timeout = 20;
 
@@ -497,7 +497,7 @@ namespace shttps {
                 size_t buffer_len = sysconf(_SC_GETPW_R_SIZE_MAX) * sizeof(char);
                 char *buffer = new char[buffer_len];
                 getpwnam_r(userid_str.c_str(), &pwd, buffer, buffer_len, &res);
-                if (res != NULL) {
+                if (res != nullptr) {
                     if (setuid(pwd.pw_uid) == 0) {
                         int old_ll = setlogmask(LOG_MASK(LOG_INFO));
                         syslog(LOG_INFO, "Server will run as user %s (%d)", userid_str.c_str(), getuid());
@@ -560,7 +560,7 @@ namespace shttps {
 
         size_t max_match_len = 0;
         std::string matching_path;
-        RequestHandler matching_handler = NULL;
+        RequestHandler matching_handler = nullptr;
 
         for (item = handler[conn.method()].rbegin(); item != handler[conn.method()].rend(); ++item) {
             size_t len = conn.uri().length() < item->first.length() ? conn.uri().length() : item->first.length();
@@ -652,14 +652,14 @@ namespace shttps {
     static int close_socket(TData *tdata) {
 
 #ifdef SHTTPS_ENABLE_SSL
-        if (tdata->cSSL != NULL) {
+        if (tdata->cSSL != nullptr) {
             int sstat;
             while ((sstat = SSL_shutdown(tdata->cSSL)) == 0);
             if (sstat < 0) {
                 syslog(LOG_WARNING, "SSL socket error: shutdown of socket failed at [%s: %d] with error code %d", __file__, __LINE__, SSL_get_error(tdata->cSSL, sstat));
             }
             SSL_free(tdata->cSSL);
-            tdata->cSSL = NULL;
+            tdata->cSSL = nullptr;
         }
 #endif
         if (shutdown(tdata->sock, SHUT_RDWR) < 0) {
@@ -684,7 +684,7 @@ namespace shttps {
         //
         SockStream *sockstream;
 #ifdef SHTTPS_ENABLE_SSL
-        if (tdata->cSSL != NULL) {
+        if (tdata->cSSL != nullptr) {
             sockstream = new SockStream(tdata->cSSL);
         }
         else {
@@ -700,7 +700,7 @@ namespace shttps {
         int keep_alive = 1;
         do {
 #ifdef SHTTPS_ENABLE_SSL
-            if (tdata->cSSL != NULL) {
+            if (tdata->cSSL != nullptr) {
                 tstatus = tdata->serv->processRequest(&ins, &os, tdata->peer_ip, tdata->peer_port, true, keep_alive);
             }
             else {
@@ -827,7 +827,7 @@ namespace shttps {
 
         delete tdata;
 
-        return NULL;
+        return nullptr;
     }
     //=========================================================================
 
@@ -843,10 +843,10 @@ namespace shttps {
         sigaddset(&set, SIGPIPE);
 
         int res;
-        if ((res = pthread_sigmask(SIG_BLOCK, &set, NULL)) != 0) {
+        if ((res = pthread_sigmask(SIG_BLOCK, &set, nullptr)) != 0) {
             syslog(LOG_ERR, "pthread_sigmask failed! (err=%d)", res);
         }
-        res = pthread_create(&sighandler_thread, NULL, &sig_thread, (void *) this);
+        res = pthread_create(&sighandler_thread, nullptr, &sig_thread, (void *) this);
 
         int old_ll = setlogmask(LOG_MASK(LOG_INFO));
         syslog(LOG_INFO, "Starting shttps server with %d threads", _nthreads);
@@ -953,11 +953,11 @@ namespace shttps {
             tmp->serv = this;
 
 #ifdef SHTTPS_ENABLE_SSL
-            SSL *cSSL = NULL;
+            SSL *cSSL = nullptr;
             if (sock == _ssl_sockfd) {
                 SSL_CTX *sslctx;
                 try {
-                    if ((sslctx = SSL_CTX_new(SSLv23_server_method())) == NULL) {
+                    if ((sslctx = SSL_CTX_new(SSLv23_server_method())) == nullptr) {
                         syslog(LOG_ERR, "OpenSSL error: SSL_CTX_new() failed");
                         throw SSLError(__file__, __LINE__, "OpenSSL error: SSL_CTX_new() failed");
                     }
@@ -977,7 +977,7 @@ namespace shttps {
                         syslog(LOG_ERR, "%s", msg.c_str());
                         throw SSLError(__file__, __LINE__, msg);
                     }
-                    if ((cSSL = SSL_new(sslctx)) == NULL) {
+                    if ((cSSL = SSL_new(sslctx)) == nullptr) {
                         std::string msg = "OpenSSL error: SSL_new() failed";
                         syslog(LOG_ERR, "%s", msg.c_str());
                         throw SSLError(__file__, __LINE__, msg);
@@ -1004,7 +1004,7 @@ namespace shttps {
                         syslog(LOG_WARNING, "SSL socket error: shutdown (2) of socket failed: %d", SSL_get_error(cSSL, sstat));
                     }
                     SSL_free(cSSL);
-                    cSSL = NULL;
+                    cSSL = nullptr;
                 }
             }
             tmp->cSSL = cSSL;
@@ -1051,7 +1051,7 @@ namespace shttps {
                 break;
             }
 #ifdef SHTTPS_ENABLE_SSL
-            if (tmp->cSSL != NULL) {
+            if (tmp->cSSL != nullptr) {
                 add_thread(thread_id, commpipe[0], tmp->sock, tmp->cSSL);
             }
             else {
@@ -1081,7 +1081,7 @@ namespace shttps {
             for (auto const &tid : thread_ids) {
                 int err;
 
-                if ((err = pthread_join(tid.first, NULL)) != 0) {
+                if ((err = pthread_join(tid.first, nullptr)) != 0) {
                     syslog(LOG_ERR, "pthread_join failed with error code %d", err);
                 }
             }
@@ -1140,7 +1140,7 @@ namespace shttps {
                 global_func.func(luaserver.lua(), conn, global_func.func_dataptr);
             }
 
-            void *hd = NULL;
+            void *hd = nullptr;
             try {
                 RequestHandler handler = getHandler(conn, &hd);
                 handler(conn, luaserver, _user_data, hd);
@@ -1184,7 +1184,7 @@ namespace shttps {
     void Server::add_thread(pthread_t thread_id_p, int commpipe_write_p, int sock_id) {
         std::lock_guard<std::mutex> thread_mutex_guard(threadlock);
 #ifdef SHTTPS_ENABLE_SSL
-        GenericSockId sid = {sock_id, NULL, commpipe_write_p};
+        GenericSockId sid = {sock_id, nullptr, commpipe_write_p};
 #else
         GenericSockId sid = {sock_id, commpipe_write_p};
 #endif
@@ -1234,7 +1234,7 @@ namespace shttps {
             return thread_ids.at(thread_id_p).ssl_sid;
         }
         catch (const std::out_of_range& oor) {
-            return NULL;
+            return nullptr;
         }
     }
     //=========================================================================

--- a/shttps/Server.cpp
+++ b/shttps/Server.cpp
@@ -1066,6 +1066,7 @@ namespace shttps {
         syslog(LOG_INFO, "Server shutting down");
         setlogmask(old_ll);
         std::vector<pthread_t> threads_to_join;
+        threads_to_join.push_back(sighandler_thread);
 
         {
             std::lock_guard<std::mutex> thread_mutex_guard(threadlock);

--- a/shttps/Server.cpp
+++ b/shttps/Server.cpp
@@ -1087,6 +1087,9 @@ namespace shttps {
             }
         }
 
+        // Close the semaphore.
+        ::sem_close(_semaphore);
+
         // std::cerr << "signal_result is " << signal_result << std::endl;
    }
     //=========================================================================

--- a/shttps/Server.h
+++ b/shttps/Server.h
@@ -145,16 +145,16 @@ namespace shttps {
         protected:
             SSL *cSSL;
         public:
-            inline SSLError (const char *file, const int line, const char *msg, SSL *cSSL_p = NULL)
+            inline SSLError (const char *file, const int line, const char *msg, SSL *cSSL_p = nullptr)
                 : Error(file, line, msg), cSSL(cSSL_p) {};
-            inline SSLError (const char *file, const int line, const std::string &msg, SSL *cSSL_p = NULL)
+            inline SSLError (const char *file, const int line, const std::string &msg, SSL *cSSL_p = nullptr)
                 : Error(file, line, msg), cSSL(cSSL_p) {};
             inline std::string to_string(void) {
                 std::stringstream ss;
                 ss << "SSL-ERROR at [" << file << ": " << line << "] ";
                 BIO *bio = BIO_new(BIO_s_mem());
                 ERR_print_errors (bio);
-                char *buf = NULL;
+                char *buf = nullptr;
                 long n =  BIO_get_mem_data (bio, &buf);
                 if (n > 0) {
                     ss << buf << " : ";
@@ -457,7 +457,7 @@ public:
          *
          * \param[in] func C++ function which extends the Lua
          */
-        inline void add_lua_globals_func(LuaSetGlobalsFunc func, void *user_data = NULL) {
+        inline void add_lua_globals_func(LuaSetGlobalsFunc func, void *user_data = nullptr) {
             GlobalFunc gf;
             gf.func = func;
             gf.func_dataptr = user_data;
@@ -478,7 +478,7 @@ public:
          *
          */
         void addRoute(Connection::HttpMethod method_p, const std::string &path, RequestHandler handler_p,
-                      void *handler_data_p = NULL);
+                      void *handler_data_p = nullptr);
 
        /*!
         * Process a request... (Eventually should be private method)

--- a/shttps/Server.h
+++ b/shttps/Server.h
@@ -381,7 +381,7 @@ public:
         /*!
          * Run the server handling requests in an infinite loop
          */
-        void run();
+        virtual void run();
 
         /*!
          * Stop the server gracefully (all destructors are called etc.) and the

--- a/shttps/Server.h
+++ b/shttps/Server.h
@@ -213,7 +213,7 @@ public:
         std::string semname; //!< name of the semaphore for restricting the number of threads
         sem_t *_semaphore; //!< semaphore
         std::atomic<int> _semcnt; //!< current value of semaphore (sem_getvalue() is not available on all systems)
-        std::map<pthread_t,GenericSockId> thread_ids; //!< Map of active worker threads
+        std::map<pthread_t, GenericSockId> thread_ids; //!< Map of active worker threads
         int _keep_alive_timeout;
         bool running; //!< Main runloop should keep on going
         std::map<std::string, RequestHandler> handler[9]; // request handlers for the different 9 request methods

--- a/shttps/Server.h
+++ b/shttps/Server.h
@@ -69,9 +69,9 @@
 namespace shttps {
 
 
-    typedef void (*RequestHandler)(Connection &, LuaServer &, void *, void *);
+    typedef void (*RequestHandler)(Connection&, LuaServer&, void *, void *);
 
-    extern void FileHandler(shttps::Connection &conn, LuaServer &lua, void *user_data, void *handler_data);
+    extern void FileHandler(Connection& conn, LuaServer& lua, void* user_data, void* handler_data);
 
     typedef enum { CONTINUE, CLOSE } ThreadStatus;
 

--- a/shttps/Shttp.cpp
+++ b/shttps/Shttp.cpp
@@ -31,13 +31,13 @@
 #include "Server.h"
 #include "LuaServer.h"
 
-shttps::Server *serverptr = NULL;
+shttps::Server *serverptr = nullptr;
 
 static sig_t old_sighandler;
 static sig_t old_broken_pipe_handler;
 
 static void sighandler(int sig) {
-    if (serverptr != NULL) {
+    if (serverptr != nullptr) {
         int old_ll = setlogmask(LOG_MASK(LOG_INFO));
         syslog(LOG_INFO, "Got SIGINT, stopping server");
         setlogmask(old_ll);
@@ -60,7 +60,7 @@ static int lua_gaga (lua_State *L)
 
     for (int i = 1; i <= top; i++) {
         const char *str = lua_tostring(L, i);
-        if (str != NULL) {
+        if (str != nullptr) {
             conn->send("GAGA: ", 5);
             conn->send(str, strlen(str));
         }
@@ -229,7 +229,7 @@ int main(int argc, char *argv[]) {
     //
     // Test handler (should be removed for production system)
     //
-    server.addRoute(shttps::Connection::GET, "/test", TestHandler, NULL);
+    server.addRoute(shttps::Connection::GET, "/test", TestHandler, nullptr);
 
     serverptr = &server;
     old_sighandler = signal(SIGINT, sighandler);

--- a/shttps/SockStream.cpp
+++ b/shttps/SockStream.cpp
@@ -38,7 +38,7 @@ SockStream::SockStream(int sock_p, int in_bufsize_p, int out_bufsize_p, int putb
     : in_bufsize(in_bufsize_p), putback_size(putback_size_p), out_bufsize(out_bufsize_p), sock(sock_p)
 {
 #ifdef SHTTPS_ENABLE_SSL
-    cSSL = NULL;
+    cSSL = nullptr;
 #endif
 
     in_buf = new char[in_bufsize + putback_size];
@@ -88,7 +88,7 @@ streambuf::int_type SockStream::underflow(void)
 
     ssize_t n;
 #ifdef SHTTPS_ENABLE_SSL
-    if (cSSL == NULL) {
+    if (cSSL == nullptr) {
         n = read(sock, start, in_bufsize);
     }
     else {
@@ -121,7 +121,7 @@ streambuf::int_type SockStream::overflow(streambuf::int_type ch)
         while (n > 0) {
             ssize_t tmp_n;
 #ifdef SHTTPS_ENABLE_SSL
-            if (cSSL == NULL) {
+            if (cSSL == nullptr) {
                 tmp_n = send(sock, out_buf + nn, n - nn, MSG_NOSIGNAL);
             }
             else {
@@ -161,7 +161,7 @@ int SockStream::sync(void)
     while (n > 0) {
         ssize_t tmp_n;
 #ifdef SHTTPS_ENABLE_SSL
-        if (cSSL == NULL) {
+        if (cSSL == nullptr) {
             tmp_n = send(sock, out_buf + nn, n - nn, MSG_NOSIGNAL);
         }
         else {

--- a/shttps/SockStream.h
+++ b/shttps/SockStream.h
@@ -101,7 +101,7 @@ namespace shttps {
         virtual int sync(void);
     protected:
     public:
-       inline SockStream() {in_buf = out_buf = NULL; in_bufsize = out_bufsize = 0; sock = -1; putback_size = 0; }
+       inline SockStream() {in_buf = out_buf = nullptr; in_bufsize = out_bufsize = 0; sock = -1; putback_size = 0; }
 
        /*!
         * Constructor of the iostream for sockets which takes the socket id and the size of the buffers

--- a/shttps/makeunique.h
+++ b/shttps/makeunique.h
@@ -1,6 +1,5 @@
-//
-// Created by Benjamin Geer on 24/01/17.
-//
+// An implementation of the C++14 make_unique function, copied from the standards document
+// <http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2013/n3656.htm>.
 
 #ifndef SIPI_MAKEUNIQUE_H
 #define SIPI_MAKEUNIQUE_H
@@ -11,21 +10,24 @@
 #include <utility>
 
 namespace shttps {
-    template<class T> struct _Unique_if {
+    template<class T>
+    struct _Unique_if {
         typedef std::unique_ptr<T> _Single_object;
     };
 
-    template<class T> struct _Unique_if<T[]> {
+    template<class T>
+    struct _Unique_if<T[]> {
         typedef std::unique_ptr<T[]> _Unknown_bound;
     };
 
-    template<class T, size_t N> struct _Unique_if<T[N]> {
+    template<class T, size_t N>
+    struct _Unique_if<T[N]> {
         typedef void _Known_bound;
     };
 
     template<class T, class... Args>
     typename _Unique_if<T>::_Single_object
-    make_unique(Args&&... args) {
+    make_unique(Args &&... args) {
         return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
     }
 
@@ -38,7 +40,7 @@ namespace shttps {
 
     template<class T, class... Args>
     typename _Unique_if<T>::_Known_bound
-    make_unique(Args&&...) = delete;
+    make_unique(Args &&...) = delete;
 }
 
 #endif //SIPI_MAKEUNIQUE_H

--- a/shttps/makeunique.h
+++ b/shttps/makeunique.h
@@ -1,0 +1,44 @@
+//
+// Created by Benjamin Geer on 24/01/17.
+//
+
+#ifndef SIPI_MAKEUNIQUE_H
+#define SIPI_MAKEUNIQUE_H
+
+#include <cstddef>
+#include <memory>
+#include <type_traits>
+#include <utility>
+
+namespace shttps {
+    template<class T> struct _Unique_if {
+        typedef std::unique_ptr<T> _Single_object;
+    };
+
+    template<class T> struct _Unique_if<T[]> {
+        typedef std::unique_ptr<T[]> _Unknown_bound;
+    };
+
+    template<class T, size_t N> struct _Unique_if<T[N]> {
+        typedef void _Known_bound;
+    };
+
+    template<class T, class... Args>
+    typename _Unique_if<T>::_Single_object
+    make_unique(Args&&... args) {
+        return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
+    }
+
+    template<class T>
+    typename _Unique_if<T>::_Unknown_bound
+    make_unique(size_t n) {
+        typedef typename std::remove_extent<T>::type U;
+        return std::unique_ptr<T>(new U[n]());
+    }
+
+    template<class T, class... Args>
+    typename _Unique_if<T>::_Known_bound
+    make_unique(Args&&...) = delete;
+}
+
+#endif //SIPI_MAKEUNIQUE_H

--- a/shttps/sole.hpp
+++ b/shttps/sole.hpp
@@ -377,7 +377,7 @@ namespace sole {
             FILETIME ft;
             uint64_t tmpres = 0;
 
-            if( NULL != tv ) {
+            if (tv != nullptr) {
                 GetSystemTimeAsFileTime(&ft);
 
                 // The GetSystemTimeAsFileTime returns the number of 100 nanosecond
@@ -400,7 +400,7 @@ namespace sole {
                 tv->tv_usec = (tmpres % 1000000UL);
             }
 
-            if( NULL != tz ) {
+            if (tz != nullptr) {
                 static bool once = true;
                 if( once ) {
                     once = false;
@@ -429,7 +429,7 @@ namespace sole {
     $lelse( $belse( // if not linux, if not bsd... valid for apple/win32
         inline int clock_gettime( int /*clk_id*/, struct timespec* t ) {
             struct timeval now;
-            int rv = gettimeofday(&now, NULL);
+            int rv = gettimeofday(&now, nullptr);
             if( rv ) return rv;
             t->tv_sec  = now.tv_sec;
             t->tv_nsec = now.tv_usec * 1000;

--- a/src/PhpSession.cpp
+++ b/src/PhpSession.cpp
@@ -223,7 +223,7 @@ namespace Sipi {
                 return obj;
             }
         } // switch
-        return NULL;
+        return nullptr;
     }
 
     PhpSession::PhpSession(ifstream *inf_p) {
@@ -251,20 +251,20 @@ namespace Sipi {
 
         cJSON *obj;
 
-        if ((obj = cJSON_GetObjectItem(session, "lang")) != NULL) {
+        if ((obj = cJSON_GetObjectItem(session, "lang")) != nullptr) {
             lang = std::string(obj->valuestring);
         }
 
-        if ((obj = cJSON_GetObjectItem(session, "language_id")) != NULL) {
+        if ((obj = cJSON_GetObjectItem(session, "language_id")) != nullptr) {
             lang_id = obj->valueint;
         }
 
 
-        if ((obj = cJSON_GetObjectItem(session, "user_id")) != NULL) {
+        if ((obj = cJSON_GetObjectItem(session, "user_id")) != nullptr) {
             user_id = obj->valueint;
         }
 
-        if ((obj = cJSON_GetObjectItem(session, "active_project")) != NULL) {
+        if ((obj = cJSON_GetObjectItem(session, "active_project")) != nullptr) {
             active_project = obj->valueint;
         }
 

--- a/src/Salsah.cpp
+++ b/src/Salsah.cpp
@@ -56,7 +56,7 @@ namespace Sipi {
             unsigned int nfields = mysql_num_fields(result);
             fields = mysql_fetch_fields(result); //fields[i].name
             if (mysql_num_rows(result) > 0) {
-                while ((row = mysql_fetch_row (result)) != NULL) {
+                while ((row = mysql_fetch_row (result)) != nullptr) {
                     std::map<std::string, std::string> m;
                     for (unsigned int i = 0; i < nfields; i++) {
                         m[std::string(fields[i].name)] = std::string(row[i] ? row[i] : "NULL");
@@ -106,7 +106,7 @@ namespace Sipi {
         std::string query5 = R"(SELECT * FROM `person_in_group` WHERE (`person_id` = {{PERSONID}}))";
 
         mysql_init(&mysql);
-        if (!mysql_real_connect (&mysql, "localhost", "salsah", "imago", "salsah", 0, NULL, 0)) {
+        if (!mysql_real_connect (&mysql, "localhost", "salsah", "imago", "salsah", 0, nullptr, 0)) {
             throw SipiError(__file__, __LINE__, mysql_error (&mysql));
         }
 

--- a/src/SipiCache.cpp
+++ b/src/SipiCache.cpp
@@ -332,23 +332,23 @@ namespace Sipi {
     }
     //============================================================================
 
-    std::string SipiCache::getNewCacheName(void)
+    /*!
+     * Creates a new cache file with a unique name.
+     *
+     * \return the name of the file.
+     */
+    std::string SipiCache::getNewCacheFileName(void)
     {
-        //
-        // create a unique temporary filename
-        //
-        std::string tmpname = _cachedir + "/cache_XXXXXXXXXX";
-        char *writable = new char[tmpname.size() + 1];
-        std::copy(tmpname.begin(), tmpname.end(), writable);
-        writable[tmpname.size()] = '\0'; // don't forget the terminating 0
+        std::string filename = _cachedir + "/cache_XXXXXXXXXX";
+        char* c_filename = &filename[0];
+        int tmp_fd = mkstemp(c_filename);
 
-        if (mktemp(writable) == NULL) {
-            throw SipiError(__file__, __LINE__, std::string("Couldn't create temporary file ") + std::string(writable), errno);
+        if (tmp_fd == -1) {
+            throw SipiError(__file__, __LINE__, std::string("Couldn't create cache file ") + filename, errno);
         }
-        tmpname = std::string(writable);
-        delete[] writable;
 
-        return tmpname;
+        close(tmp_fd);
+        return filename;
     }
     //============================================================================
 

--- a/src/SipiCache.cpp
+++ b/src/SipiCache.cpp
@@ -126,7 +126,7 @@ namespace Sipi {
         // now we looking for files that are not in the list of cached files
         // and we delete them
         //
-        n = scandir(_cachedir.c_str(), &namelist, NULL, alphasort);
+        n = scandir(_cachedir.c_str(), &namelist, nullptr, alphasort);
         if (n < 0) {
             perror("scandir");
         }

--- a/src/SipiCmdParams.cpp
+++ b/src/SipiCmdParams.cpp
@@ -33,7 +33,7 @@
 namespace Sipi {
 
     SipiCmdParams::SipiCmdParams (int argc, char *argv[], const char *infostr) {
-        if (infostr != NULL) {
+        if (infostr != nullptr) {
             info = infostr;
         }
         SipiCmdParams::argv.resize (argc);

--- a/src/SipiHttpServer.cpp
+++ b/src/SipiHttpServer.cpp
@@ -355,7 +355,7 @@ namespace Sipi {
         // get cache info
         //
         SipiCache *cache = serv->cache();
-        if ((cache == NULL) || !cache->getSize(infile, width, height)) {
+        if ((cache == nullptr) || !cache->getSize(infile, width, height)) {
             Sipi::SipiImage tmpimg;
             try {
                 tmpimg.getDim(infile, width, height);
@@ -845,7 +845,7 @@ namespace Sipi {
             //
             // get image dimensions, needed for get_canonical...
             //
-            if ((cache == NULL) || !cache->getSize(infile, img_w, img_h)) {
+            if ((cache == nullptr) || !cache->getSize(infile, img_w, img_h)) {
                 Sipi::SipiImage tmpimg;
                 try {
                     tmpimg.getDim(infile, img_w, img_h);
@@ -942,7 +942,7 @@ namespace Sipi {
         }
         syslog(LOG_DEBUG, "Checking for cache...");
 
-        if (cache != NULL) {
+        if (cache != nullptr) {
             syslog(LOG_DEBUG, "Cache found, testing for canonical %s", canonical.c_str());
             std::string cachefile = cache->check(infile, canonical);
             if (!cachefile.empty()) {
@@ -1049,7 +1049,7 @@ namespace Sipi {
         conn_obj.header("Cache-Control", "must-revalidate, post-check=0, pre-check=0");
 
         std::string cachefile;
-        if (cache != NULL) {
+        if (cache != nullptr) {
             cachefile = cache->getNewCacheFileName();
             syslog(LOG_INFO, "Writing new cache file %s", cachefile.c_str());
         }
@@ -1065,7 +1065,7 @@ namespace Sipi {
                     Sipi::SipiIcc icc = Sipi::SipiIcc(Sipi::icc_sRGB); // force sRGB !!
                     img.convertToIcc(icc, 8);
                     conn_obj.setChunkedTransfer();
-                    if (cache != NULL) {
+                    if (cache != nullptr) {
                         conn_obj.openCacheFile(cachefile);
                     }
                     syslog(LOG_DEBUG, "Before writing JPG...");
@@ -1074,14 +1074,14 @@ namespace Sipi {
                     }
                     catch (SipiImageError &err) {
                         syslog(LOG_ERR, "%s", err.to_string().c_str());
-                        if (cache != NULL) {
+                        if (cache != nullptr) {
                             conn_obj.closeCacheFile();
                             unlink(cachefile.c_str());
                         }
                         break;
                     }
                     syslog(LOG_DEBUG, "After writing JPG...");
-                    if (cache != NULL) {
+                    if (cache != nullptr) {
                         conn_obj.closeCacheFile();
                         syslog(LOG_INFO, "Adding cachefile %s to internal list", cachefile.c_str());
                         cache->add(infile, canonical, cachefile, img_w, img_h);
@@ -1094,7 +1094,7 @@ namespace Sipi {
                     conn_obj.header("Content-Type", "image/jp2"); // set the header (mimetype)
                     conn_obj.setChunkedTransfer();
                     syslog(LOG_DEBUG, "Before writing J2K...");
-                    if (cache != NULL) {
+                    if (cache != nullptr) {
                         conn_obj.openCacheFile(cachefile);
                     }
                     try {
@@ -1102,7 +1102,7 @@ namespace Sipi {
                     }
                     catch (SipiImageError &err) {
                         syslog(LOG_ERR, "%s", err.to_string().c_str());
-                        if (cache != NULL) {
+                        if (cache != nullptr) {
                             conn_obj.closeCacheFile();
                             unlink(cachefile.c_str());
                         }
@@ -1116,7 +1116,7 @@ namespace Sipi {
                     conn_obj.header("Content-Type", "image/tiff"); // set the header (mimetype)
                     // no chunked transfer needed...
                     syslog(LOG_DEBUG, "Before writing TIF...");
-                    if (cache != NULL) {
+                    if (cache != nullptr) {
                         conn_obj.openCacheFile(cachefile);
                     }
                     try {
@@ -1124,14 +1124,14 @@ namespace Sipi {
                     }
                     catch (SipiImageError &err) {
                         syslog(LOG_ERR, "%s", err.to_string().c_str());
-                        if (cache != NULL) {
+                        if (cache != nullptr) {
                             conn_obj.closeCacheFile();
                             unlink(cachefile.c_str());
                         }
                         break;
                     }
                     syslog(LOG_DEBUG, "After writing TIF...");
-                    if (cache != NULL) {
+                    if (cache != nullptr) {
                         conn_obj.closeCacheFile();
                         syslog(LOG_DEBUG, "Adding cachefile %s to internal list", cachefile.c_str());
                         cache->add(infile, canonical, cachefile, img_w, img_h);
@@ -1143,10 +1143,10 @@ namespace Sipi {
                     conn_obj.header("Link", canonical_header);
                     conn_obj.header("Content-Type", "image/png"); // set the header (mimetype)
                     conn_obj.setChunkedTransfer();
-                    if (cache != NULL) {
+                    if (cache != nullptr) {
                         conn_obj.openCacheFile(cachefile);
                     }
-                    if (cache != NULL) {
+                    if (cache != nullptr) {
                         conn_obj.openCacheFile(cachefile);
                     }
                     syslog(LOG_DEBUG, "Before writing PNG...");
@@ -1155,14 +1155,14 @@ namespace Sipi {
                     }
                     catch (SipiImageError &err) {
                         syslog(LOG_ERR, "%s", err.to_string().c_str());
-                        if (cache != NULL) {
+                        if (cache != nullptr) {
                             conn_obj.closeCacheFile();
                             unlink(cachefile.c_str());
                         }
                         break;
                     }
                     syslog(LOG_DEBUG, "After writing PNG...");
-                    if (cache != NULL) {
+                    if (cache != nullptr) {
                         conn_obj.closeCacheFile();
                         syslog(LOG_DEBUG, "Adding cachefile %s to internal list", cachefile.c_str());
                         cache->add(infile, canonical, cachefile, img_w, img_h);
@@ -1227,13 +1227,13 @@ namespace Sipi {
         : Server::Server(port_p, nthreads_p, userid_str, logfile_p, loglevel_p)
     {
         _salsah_prefix = "imgrep";
-        _cache = NULL;
+        _cache = nullptr;
     }
     //=========================================================================
 
     SipiHttpServer::~SipiHttpServer()
     {
-        if (_cache != NULL) delete _cache;
+        if (_cache != nullptr) delete _cache;
     }
     //=========================================================================
 
@@ -1243,7 +1243,7 @@ namespace Sipi {
             _cache = new SipiCache(cachedir_p, max_cachesize_p, max_nfiles_p, cache_hysteresis_p);
         }
         catch (const SipiError &err) {
-            _cache = NULL;
+            _cache = nullptr;
             syslog(LOG_WARNING, "Couldn't open cache directory %s: %s", cachedir_p.c_str(), err.to_string().c_str());
         }
     }

--- a/src/SipiHttpServer.cpp
+++ b/src/SipiHttpServer.cpp
@@ -1050,7 +1050,7 @@ namespace Sipi {
 
         std::string cachefile;
         if (cache != NULL) {
-            cachefile = cache->getNewCacheName();
+            cachefile = cache->getNewCacheFileName();
             syslog(LOG_INFO, "Writing new cache file %s", cachefile.c_str());
         }
         try {

--- a/src/SipiHttpServer.cpp
+++ b/src/SipiHttpServer.cpp
@@ -354,7 +354,7 @@ namespace Sipi {
         //
         // get cache info
         //
-        SipiCache *cache = serv->cache();
+        std::shared_ptr<SipiCache> cache = serv->cache();
         if ((cache == nullptr) || !cache->getSize(infile, width, height)) {
             Sipi::SipiImage tmpimg;
             try {
@@ -829,7 +829,7 @@ namespace Sipi {
         //
         // get cache info
         //
-        SipiCache *cache = serv->cache();
+        std::shared_ptr<SipiCache> cache = serv->cache();
 
         int img_w = 0, img_h = 0;
         if (in_format == SipiQualityFormat::PDF) {
@@ -1248,16 +1248,10 @@ namespace Sipi {
     }
     //=========================================================================
 
-    SipiHttpServer::~SipiHttpServer()
-    {
-        if (_cache != nullptr) delete _cache;
-    }
-    //=========================================================================
-
     void SipiHttpServer::cache(const std::string &cachedir_p, long long max_cachesize_p, unsigned max_nfiles_p, float cache_hysteresis_p)
     {
         try {
-            _cache = new SipiCache(cachedir_p, max_cachesize_p, max_nfiles_p, cache_hysteresis_p);
+            _cache = std::make_shared<SipiCache>(cachedir_p, max_cachesize_p, max_nfiles_p, cache_hysteresis_p);
         }
         catch (const SipiError &err) {
             _cache = nullptr;

--- a/src/SipiImage.cpp
+++ b/src/SipiImage.cpp
@@ -41,12 +41,12 @@ static const char __file__[] = __FILE__;
 
 namespace Sipi {
 
-  std::unordered_map<std::string,SipiIO*> SipiImage::io = {
-    {"tif", new SipiIOTiff()},
-    {"jpx", new SipiIOJ2k()},
-    //{"jpx", new SipiIOOpenJ2k()},
-    {"jpg", new SipiIOJpeg()},
-    {"png", new SipiIOPng()}
+  std::unordered_map<std::string, std::shared_ptr<SipiIO> > SipiImage::io = {
+    {"tif", std::make_shared<SipiIOTiff>()},
+    {"jpx", std::make_shared<SipiIOJ2k>()},
+    //{"jpx", std::make_shared<SipiIOOpenJ2k>()},
+    {"jpg", std::make_shared<SipiIOJpeg>()},
+    {"png", std::make_shared<SipiIOPng>()}
   };
 
   std::unordered_map<std::string, std::string> SipiImage::mimetypes = {

--- a/src/SipiImage.cpp
+++ b/src/SipiImage.cpp
@@ -64,13 +64,13 @@ namespace Sipi {
         ny = 0;
         nc = 0;
         bps = 0;
-        pixels = NULL;
-        xmp = NULL;
-        icc = NULL;
-        iptc = NULL;
-        exif = NULL;
+        pixels = nullptr;
+        xmp = nullptr;
+        icc = nullptr;
+        iptc = nullptr;
+        exif = nullptr;
         skip_metadata = SKIP_NONE;
-        conobj = NULL;
+        conobj = nullptr;
     };
     //============================================================================
 
@@ -139,12 +139,12 @@ namespace Sipi {
         else {
             throw SipiImageError(__file__, __LINE__, "Image with no content");
         }
-        xmp = NULL;
-        icc = NULL;
-        iptc = NULL;
-        exif = NULL;
+        xmp = nullptr;
+        icc = nullptr;
+        iptc = nullptr;
+        exif = nullptr;
         skip_metadata = SKIP_NONE;
-        conobj = NULL;
+        conobj = nullptr;
     }
     //============================================================================
 
@@ -367,7 +367,7 @@ namespace Sipi {
 
     void SipiImage::convertToIcc(const SipiIcc &target_icc_p, int new_bps) {
         cmsUInt32Number in_formatter, out_formatter;
-        if (icc == NULL) {
+        if (icc == nullptr) {
             switch (nc) {
                 case 1: {
                     icc = new SipiIcc(icc_GRAY_D50); // assume gray value image with D50
@@ -401,7 +401,7 @@ namespace Sipi {
         }
 
         hTransform = cmsCreateTransform(icc->getIccProfile(), in_formatter, target_icc_p.getIccProfile(), out_formatter, INTENT_PERCEPTUAL, 0);
-        if (hTransform == NULL) {
+        if (hTransform == nullptr) {
             throw SipiImageError(__file__, __LINE__, "Couldn't create color transform");
         }
         cmsDoTransform(hTransform, inbuf, outbuf, nx*ny);
@@ -1057,7 +1057,7 @@ namespace Sipi {
             word *inbuf = (word *) pixels;
             //byte *outbuf = new(std::nothrow) Sipi::byte[nc*nx*ny];
             byte *outbuf = new(std::nothrow) byte[nc*nx*ny];
-            if (outbuf == NULL) return false;
+            if (outbuf == nullptr) return false;
             for (unsigned int j = 0; j < ny; j++) {
                 for (unsigned int i = 0; i < nx; i++) {
                     for (unsigned int k = 0; k < nc; k++) {
@@ -1090,7 +1090,7 @@ namespace Sipi {
         if (!doit) return true; // we have to do nothing, it's already bitonal
 
         short *outbuf = new(std::nothrow) short[nx*ny]; // must be signed!! Error propagation my result inm values < 0 or > 255
-        if (outbuf == NULL) return false; // TODO: throw an error with a reasonable error message
+        if (outbuf == nullptr) return false; // TODO: throw an error with a reasonable error message
         for (int i = 0; i < nx*ny; i++) {
             outbuf[i] = pixels[i];  // copy buffer
         }
@@ -1116,7 +1116,7 @@ namespace Sipi {
     bool SipiImage::add_watermark(std::string wmfilename) {
         int wm_nx, wm_ny, wm_nc;
     	byte *wmbuf = read_watermark(wmfilename, wm_nx, wm_ny, wm_nc);
-        if (wmbuf == NULL) {
+        if (wmbuf == nullptr) {
             throw SipiImageError(__file__, __LINE__, "Cannot read watermark file " + wmfilename);
         }
 
@@ -1162,7 +1162,7 @@ namespace Sipi {
 
 
     SipiImage &SipiImage::operator-=(const SipiImage &rhs) {
-        SipiImage *new_rhs = NULL;
+        SipiImage *new_rhs = nullptr;
 
         if ((nc != rhs.nc) || (bps != rhs.bps) || (photo != rhs.photo)) {
             std::stringstream ss;
@@ -1182,7 +1182,7 @@ namespace Sipi {
         switch (bps) {
             case 8: {
                 byte *ltmp = (byte *) pixels;
-                byte *rtmp = (new_rhs == NULL) ? (byte *) rhs.pixels : (byte *) new_rhs->pixels;
+                byte *rtmp = (new_rhs == nullptr) ? (byte *) rhs.pixels : (byte *) new_rhs->pixels;
                 for (int j = 0; j < ny; j++) {
                     for (int i = 0; i < nx; i++) {
                         for (int k = 0; k < nc; k++) {
@@ -1196,7 +1196,7 @@ namespace Sipi {
             }
             case 16: {
                 word *ltmp = (word *) pixels;
-                word *rtmp = (new_rhs == NULL) ? (word *) rhs.pixels : (word *) new_rhs->pixels;
+                word *rtmp = (new_rhs == nullptr) ? (word *) rhs.pixels : (word *) new_rhs->pixels;
                 for (int j = 0; j < ny; j++) {
                     for (int i = 0; i < nx; i++) {
                         for (int k = 0; k < nc; k++) {
@@ -1210,7 +1210,7 @@ namespace Sipi {
             }
             default: {
                 delete [] diffbuf;
-                if (new_rhs != NULL) delete new_rhs;
+                if (new_rhs != nullptr) delete new_rhs;
                 throw SipiImageError(__file__, __LINE__, "Bits per pixels not supported");
             }
         }
@@ -1252,12 +1252,12 @@ namespace Sipi {
             }
             default: {
                 delete [] diffbuf;
-                if (new_rhs != NULL) delete new_rhs;
+                if (new_rhs != nullptr) delete new_rhs;
                 throw SipiImageError(__file__, __LINE__, "Bits per pixels not supported");
             }
         }
 
-        if (new_rhs != NULL) delete new_rhs;
+        if (new_rhs != nullptr) delete new_rhs;
 
         return *this;
     }
@@ -1272,7 +1272,7 @@ namespace Sipi {
     /*==========================================================================*/
 
     SipiImage &SipiImage::operator+=(const SipiImage &rhs) {
-        SipiImage *new_rhs = NULL;
+        SipiImage *new_rhs = nullptr;
 
         if ((nc != rhs.nc) || (bps != rhs.bps) || (photo != rhs.photo)) {
             std::stringstream ss;
@@ -1292,7 +1292,7 @@ namespace Sipi {
         switch (bps) {
             case 8: {
                 byte *ltmp = (byte *) pixels;
-                byte *rtmp = (new_rhs == NULL) ? (byte *) rhs.pixels : (byte *) new_rhs->pixels;
+                byte *rtmp = (new_rhs == nullptr) ? (byte *) rhs.pixels : (byte *) new_rhs->pixels;
                 for (int j = 0; j < ny; j++) {
                     for (int i = 0; i < nx; i++) {
                         for (int k = 0; k < nc; k++) {
@@ -1306,7 +1306,7 @@ namespace Sipi {
             }
             case 16: {
                 word *ltmp = (word *) pixels;
-                word *rtmp = (new_rhs == NULL) ? (word *) rhs.pixels : (word *) new_rhs->pixels;
+                word *rtmp = (new_rhs == nullptr) ? (word *) rhs.pixels : (word *) new_rhs->pixels;
                 for (int j = 0; j < ny; j++) {
                     for (int i = 0; i < nx; i++) {
                         for (int k = 0; k < nc; k++) {
@@ -1320,7 +1320,7 @@ namespace Sipi {
             }
             default: {
                 delete [] diffbuf;
-                if (new_rhs != NULL) delete new_rhs;
+                if (new_rhs != nullptr) delete new_rhs;
                 throw SipiImageError(__file__, __LINE__, "Bits per pixels not supported");
             }
         }
@@ -1359,7 +1359,7 @@ namespace Sipi {
             }
             default: {
                 delete [] diffbuf;
-                if (new_rhs != NULL) delete new_rhs;
+                if (new_rhs != nullptr) delete new_rhs;
                 throw SipiImageError(__file__, __LINE__, "Bits per pixels not supported");
             }
         }

--- a/src/SipiLua.cpp
+++ b/src/SipiLua.cpp
@@ -58,7 +58,7 @@ namespace Sipi {
         lua_remove(L, -1); // remove from stack
         SipiCache *cache = server->cache();
 
-        if (cache == NULL) {
+        if (cache == nullptr) {
             lua_pushnil(L);
             return 1;
         }
@@ -80,7 +80,7 @@ namespace Sipi {
         lua_remove(L, -1); // remove from stack
         SipiCache *cache = server->cache();
 
-        if (cache == NULL) {
+        if (cache == nullptr) {
             lua_pushnil(L);
             return 1;
         }
@@ -102,7 +102,7 @@ namespace Sipi {
         lua_remove(L, -1); // remove from stack
         SipiCache *cache = server->cache();
 
-        if (cache == NULL) {
+        if (cache == nullptr) {
             lua_pushnil(L);
             return 1;
         }
@@ -124,7 +124,7 @@ namespace Sipi {
         lua_remove(L, -1); // remove from stack
         SipiCache *cache = server->cache();
 
-        if (cache == NULL) {
+        if (cache == nullptr) {
             lua_pushnil(L);
             return 1;
         }
@@ -147,7 +147,7 @@ namespace Sipi {
         lua_remove(L, -1); // remove from stack
         SipiCache *cache = server->cache();
 
-        if (cache == NULL) {
+        if (cache == nullptr) {
             lua_pushnil(L);
             return 1;
         }
@@ -208,7 +208,7 @@ namespace Sipi {
         lua_pop(L, top);
         SipiCache *cache = server->cache();
 
-        if (cache == NULL) {
+        if (cache == nullptr) {
             lua_pushnil(L);
             return 1;
         }
@@ -243,7 +243,7 @@ namespace Sipi {
 
         int top = lua_gettop(L);
 
-        if (cache == NULL) {
+        if (cache == nullptr) {
             lua_pop(L, top);
             lua_pushnil(L);
             return 1;
@@ -275,7 +275,7 @@ namespace Sipi {
         lua_remove(L, -1); // remove from stack
         SipiCache *cache = server->cache();
 
-        if (cache == NULL) {
+        if (cache == nullptr) {
             lua_pushnil(L);
             return 1;
         }
@@ -303,7 +303,7 @@ namespace Sipi {
 
     static SImage *toSImage(lua_State *L, int index) {
         SImage *img = (SImage *) lua_touserdata(L, index);
-        if (img == NULL) {
+        if (img == nullptr) {
             lua_pushstring(L, "Type error! Not userdata object");
             lua_error(L);
         }
@@ -315,7 +315,7 @@ namespace Sipi {
         SImage *img;
         luaL_checktype(L, index, LUA_TUSERDATA);
         img = (SImage *) luaL_checkudata(L, index, SIMAGE);
-        if (img == NULL) {
+        if (img == nullptr) {
             lua_pushstring(L, "Type error! Expected an SipiImage!");
             lua_error(L);
         }
@@ -352,8 +352,8 @@ namespace Sipi {
         }
         const char *imgpath = lua_tostring(L, 1);
 
-        SipiRegion *region = NULL;
-        SipiSize *size = NULL;
+        SipiRegion *region = nullptr;
+        SipiSize *size = nullptr;
         std::string original;
         shttps::HashType htype = shttps::HashType::sha256;
         if (top == 2) {
@@ -518,7 +518,7 @@ namespace Sipi {
         }
         else {
             SImage *img = checkSImage(L, 1);
-            if (img == NULL) {
+            if (img == nullptr) {
                 lua_pop(L, top);
                 lua_pushboolean(L, false);
                 lua_pushstring(L, "'SipiImage.dims()': not a valid image!");

--- a/src/SipiLua.cpp
+++ b/src/SipiLua.cpp
@@ -56,7 +56,7 @@ namespace Sipi {
         lua_getglobal(L, sipiserver);
         SipiHttpServer *server = (SipiHttpServer *) lua_touserdata(L, -1);
         lua_remove(L, -1); // remove from stack
-        SipiCache *cache = server->cache();
+        std::shared_ptr<SipiCache> cache = server->cache();
 
         if (cache == nullptr) {
             lua_pushnil(L);
@@ -78,7 +78,7 @@ namespace Sipi {
         lua_getglobal(L, sipiserver);
         SipiHttpServer *server = (SipiHttpServer *) lua_touserdata(L, -1);
         lua_remove(L, -1); // remove from stack
-        SipiCache *cache = server->cache();
+        std::shared_ptr<SipiCache> cache = server->cache();
 
         if (cache == nullptr) {
             lua_pushnil(L);
@@ -100,7 +100,7 @@ namespace Sipi {
         lua_getglobal(L, sipiserver);
         SipiHttpServer *server = (SipiHttpServer *) lua_touserdata(L, -1);
         lua_remove(L, -1); // remove from stack
-        SipiCache *cache = server->cache();
+        std::shared_ptr<SipiCache> cache = server->cache();
 
         if (cache == nullptr) {
             lua_pushnil(L);
@@ -122,7 +122,7 @@ namespace Sipi {
         lua_getglobal(L, sipiserver);
         SipiHttpServer *server = (SipiHttpServer *) lua_touserdata(L, -1);
         lua_remove(L, -1); // remove from stack
-        SipiCache *cache = server->cache();
+        std::shared_ptr<SipiCache> cache = server->cache();
 
         if (cache == nullptr) {
             lua_pushnil(L);
@@ -145,7 +145,7 @@ namespace Sipi {
         lua_getglobal(L, sipiserver);
         SipiHttpServer *server = (SipiHttpServer *) lua_touserdata(L, -1);
         lua_remove(L, -1); // remove from stack
-        SipiCache *cache = server->cache();
+        std::shared_ptr<SipiCache> cache = server->cache();
 
         if (cache == nullptr) {
             lua_pushnil(L);
@@ -206,7 +206,7 @@ namespace Sipi {
             sortmethod = std::string(lua_tostring(L, 1));
         }
         lua_pop(L, top);
-        SipiCache *cache = server->cache();
+        std::shared_ptr<SipiCache> cache = server->cache();
 
         if (cache == nullptr) {
             lua_pushnil(L);
@@ -239,7 +239,7 @@ namespace Sipi {
         lua_getglobal(L, sipiserver);
         SipiHttpServer *server = (SipiHttpServer *) lua_touserdata(L, -1);
         lua_remove(L, -1); // remove from stack
-        SipiCache *cache = server->cache();
+        std::shared_ptr<SipiCache> cache = server->cache();
 
         int top = lua_gettop(L);
 
@@ -253,12 +253,7 @@ namespace Sipi {
         if (top == 1) {
             canonical = std::string(lua_tostring(L, 1));
             lua_pop(L, 1);
-            if (cache->remove(canonical)) {
-                lua_pushboolean(L, true);
-            }
-            else {
-                lua_pushboolean(L, false);
-            }
+            lua_pushboolean(L, cache->remove(canonical));
         }
         else {
             lua_pop(L, top);
@@ -273,7 +268,7 @@ namespace Sipi {
         lua_getglobal(L, sipiserver);
         SipiHttpServer *server = (SipiHttpServer *) lua_touserdata(L, -1);
         lua_remove(L, -1); // remove from stack
-        SipiCache *cache = server->cache();
+        std::shared_ptr<SipiCache> cache = server->cache();
 
         if (cache == nullptr) {
             lua_pushnil(L);

--- a/src/SipiLua.cpp
+++ b/src/SipiLua.cpp
@@ -352,8 +352,8 @@ namespace Sipi {
         }
         const char *imgpath = lua_tostring(L, 1);
 
-        SipiRegion *region = nullptr;
-        SipiSize *size = nullptr;
+        std::shared_ptr<SipiRegion> region;
+        std::shared_ptr<SipiSize> size;
         std::string original;
         shttps::HashType htype = shttps::HashType::sha256;
         if (top == 2) {
@@ -370,9 +370,9 @@ namespace Sipi {
             while (lua_next(L, 2) != 0) {
                 if (lua_isstring(L, -2)) {
                     const char *param = lua_tostring(L, -2);
-                   if (strcmp(param, "region") == 0) {
+                    if (strcmp(param, "region") == 0) {
                         if (lua_isstring(L, -1)) {
-                            region = new SipiRegion(lua_tostring(L, -1));
+                            region = std::make_shared<SipiRegion>(lua_tostring(L, -1));
                         }
                         else {
                             lua_pop(L, lua_gettop(L));
@@ -383,7 +383,7 @@ namespace Sipi {
                     }
                     else if (strcmp(param, "size") == 0) {
                         if (lua_isstring(L, -1)) {
-                            size = new SipiSize(lua_tostring(L, -1));
+                            size = std::make_shared<SipiSize>(lua_tostring(L, -1));
                         }
                         else {
                             lua_pop(L, lua_gettop(L));
@@ -394,7 +394,7 @@ namespace Sipi {
                     }
                     else if (strcmp(param, "reduce") == 0) {
                         if (lua_isnumber(L, -1)) {
-                            size = new SipiSize((int) lua_tointeger(L, -1));
+                            size = std::make_shared<SipiSize>(static_cast<int>(lua_tointeger(L, -1)));
                         }
                         else {
                             lua_pop(L, lua_gettop(L));
@@ -473,8 +473,6 @@ namespace Sipi {
             }
         }
         catch(SipiImageError &err) {
-            delete region;
-            delete size;
             lua_pop(L, lua_gettop(L));
             lua_pushboolean(L, false);
             std::stringstream ss;
@@ -483,9 +481,6 @@ namespace Sipi {
             lua_pushstring(L, ss.str().c_str());
             return 2;
         }
-
-        delete region;
-        delete size;
 
         return 2;
     }
@@ -607,9 +602,9 @@ namespace Sipi {
         const char *regionstr = lua_tostring(L, 2);
         lua_pop(L, top);
 
-        SipiRegion *reg;
+        std::shared_ptr<SipiRegion> reg;
         try {
-            reg = new SipiRegion(regionstr);
+            reg = std::make_shared<SipiRegion>(regionstr);
         }
         catch (SipiError &err) {
             lua_pushboolean(L, false);
@@ -618,8 +613,8 @@ namespace Sipi {
             lua_pushstring(L, ss.str().c_str());
             return 2;
         }
+
         img->image->crop(reg); // can not throw exception!
-        delete reg;
 
         lua_pushboolean(L, true);
         lua_pushnil(L);

--- a/src/SipiParam.cpp
+++ b/src/SipiParam.cpp
@@ -149,8 +149,8 @@ namespace Sipi {
 
         char *tmpstr = (char *) alloca (strlen (list_p) + 1);
         strcpy (tmpstr, list_p);
-        char *tok = NULL;
-        while ((tok = strsep (&tmpstr, ":")) != NULL) {
+        char *tok = nullptr;
+        while ((tok = strsep (&tmpstr, ":")) != nullptr) {
             if (*tok != '\0') {
                 std::string stmp = tok;
                 options.push_back (stmp);

--- a/src/SipiParamValue.cpp
+++ b/src/SipiParamValue.cpp
@@ -42,7 +42,7 @@ namespace Sipi {
   //
   SipiParamValue::SipiParamValue (void) {
     dataType = SipiUndefined;
-    val = NULL;
+    val = nullptr;
   }
   //============================================================================
 
@@ -98,7 +98,7 @@ namespace Sipi {
     if (dataType == SipiString) {
       delete sval;
     }
-    val = NULL;
+    val = nullptr;
   }
   //============================================================================
 
@@ -231,7 +231,7 @@ namespace Sipi {
 	return (round (fval));
       }
       case SipiString: {
-	int itmp = (int) strtol((*sval).c_str(), (char **) NULL, 10);
+	int itmp = (int) strtol((*sval).c_str(), (char **) nullptr, 10);
 	if (errno == EINVAL) {
 	  SipiError sipi_error (__FILE__, __LINE__,
 				"invalid datatype: conversion \"SipiString\" to  \"SipiInteger\" impossible!");

--- a/src/formats/SipiIOJ2k.cpp
+++ b/src/formats/SipiIOJ2k.cpp
@@ -191,7 +191,7 @@ namespace Sipi {
         kdu_customize_warnings(&kdu_sipi_warn);
         kdu_customize_errors(&kdu_sipi_error);
 
-        kdu_core::kdu_compressed_source *input = NULL;
+        kdu_core::kdu_compressed_source *input = nullptr;
         kdu_supp::kdu_simple_file_source file_in;
 
         kdu_supp::jp2_family_src jp2_ultimate_src;
@@ -297,7 +297,7 @@ namespace Sipi {
         //
         kdu_core::kdu_dims roi;
         bool do_roi = false;
-        if ((region != NULL) && (region->getType()) != SipiRegion::FULL) {
+        if ((region != nullptr) && (region->getType()) != SipiRegion::FULL) {
             try {
                 region->crop_coords(__nx, __ny, roi.pos.x, roi.pos.y, roi.size.x, roi.size.y);
                 do_roi = true;
@@ -317,7 +317,7 @@ namespace Sipi {
         int reduce = 0;
         int nnx, nny;
         bool redonly = true; // we assume that only a reduce is necessary
-        if ((size != NULL) && (size->getType() != SipiSize::FULL)) {
+        if ((size != nullptr) && (size->getType() != SipiSize::FULL)) {
             if (do_roi) {
                 size->get_size(roi.size.x, roi.size.y, nnx, nny, reduce, redonly);
             }
@@ -328,7 +328,7 @@ namespace Sipi {
         }
 
         if (reduce < 0) reduce = 0;
-        codestream.apply_input_restrictions(0, 0, reduce, 0, do_roi ? &roi : NULL);
+        codestream.apply_input_restrictions(0, 0, reduce, 0, do_roi ? &roi : nullptr);
 
 
         // Determine number of components to decompress
@@ -421,7 +421,7 @@ namespace Sipi {
                 bool *get_signed = new bool[img->nc];
                 for (int i = 0; i < img->nc; i++) get_signed[i] = FALSE;
                 kdu_core::kdu_int16 *buffer16 = new kdu_core::kdu_int16[(int) dims.area()*img->nc];
-                decompressor.pull_stripe(buffer16, stripe_heights, NULL, NULL, NULL, NULL, get_signed);
+                decompressor.pull_stripe(buffer16, stripe_heights, nullptr, nullptr, nullptr, nullptr, get_signed);
                 img->pixels = (byte *) buffer16;
                 break;
             }
@@ -438,7 +438,7 @@ namespace Sipi {
         input->close();
         jpx_in.close(); // Not really necessary here.
 
-        if ((size != NULL) && (!redonly)) {
+        if ((size != nullptr) && (!redonly)) {
             img->scale(nnx, nny);
         }
 
@@ -456,7 +456,7 @@ namespace Sipi {
         kdu_supp::jp2_family_src jp2_ultimate_src;
         kdu_supp::jpx_source jpx_in;
         kdu_supp::jpx_codestream_source jpx_stream;
-        kdu_core::kdu_compressed_source *input = NULL;
+        kdu_core::kdu_compressed_source *input = nullptr;
         kdu_supp::kdu_simple_file_source file_in;
 
         jp2_ultimate_src.open(filepath.c_str());
@@ -544,7 +544,7 @@ namespace Sipi {
 
         	kdu_codestream codestream;
 
-            kdu_compressed_target *output = NULL;
+            kdu_compressed_target *output = nullptr;
             jp2_family_tgt jp2_ultimate_tgt;
             jpx_target jpx_out;
             jpx_codestream_target jpx_stream;
@@ -555,7 +555,7 @@ namespace Sipi {
             jp2_channels jp2_family_channels;
             jp2_colour jp2_family_colour;
 
-            J2kHttpStream *http = NULL;
+            J2kHttpStream *http = nullptr;
             if (filepath == "HTTP") {
                 shttps::Connection *conobj = img->connection();
                 http = new J2kHttpStream(conobj);
@@ -606,7 +606,7 @@ namespace Sipi {
 
             jp2_family_dimensions.init(&siz); // initalize dimension box
 
-            if (img->icc != NULL) {
+            if (img->icc != nullptr) {
                 PredefinedProfiles icc_type = img->icc->getProfileType();
                 switch (icc_type) {
                     case icc_undefined: {
@@ -676,7 +676,7 @@ namespace Sipi {
             for (int c = 0; c < img->es.size(); c++) jp2_family_channels.set_opacity_mapping(img->nc + c, img->nc + c);
             jpx_out.write_headers();
 
-            if (img->iptc != NULL) {
+            if (img->iptc != nullptr) {
                 unsigned int iptc_len = 0;
                 kdu_byte *iptc_buf = img->iptc->iptcBytes(iptc_len);
                 write_iptc_box(&jp2_ultimate_tgt, iptc_buf, iptc_len);
@@ -685,7 +685,7 @@ namespace Sipi {
             //
             // write EXIF here
             //
-            if (img->exif != NULL) {
+            if (img->exif != nullptr) {
                 unsigned int exif_len = 0;
                 kdu_byte *exif_buf = img->exif->exifBytes(exif_len);
                 write_exif_box(&jp2_ultimate_tgt, exif_buf, exif_len);
@@ -694,7 +694,7 @@ namespace Sipi {
             //
             // write XMP data here
             //
-            if (img->xmp != NULL) {
+            if (img->xmp != nullptr) {
                 unsigned int len = 0;
                 const char *xmp_buf = img->xmp->xmpBytes(len);
                 if (len > 0) {
@@ -709,7 +709,7 @@ namespace Sipi {
 
             codestream.access_siz()->finalize_all();
 
-            kdu_thread_env env, *env_ref = NULL;
+            kdu_thread_env env, *env_ref = nullptr;
             if (num_threads > 0) {
                 env.create();
                 for (int nt=1; nt < num_threads; nt++) {
@@ -722,7 +722,7 @@ namespace Sipi {
             // Now compress the image in one hit, using `kdu_stripe_compressor'
             kdu_stripe_compressor compressor;
             //compressor.start(codestream);
-            compressor.start(codestream, 0, NULL, NULL, 0, false, false, true, 0.0, 0, false, env_ref);
+            compressor.start(codestream, 0, nullptr, nullptr, 0, false, false, true, 0.0, 0, false, env_ref);
 
             int *stripe_heights = new int[img->nc];
             for (int i = 0; i < img->nc; i++) {
@@ -740,7 +740,7 @@ namespace Sipi {
                     precisions[i] = img->bps;
                     is_signed[i] = false;
                 }
-                compressor.push_stripe(buf, stripe_heights, NULL, NULL, NULL, precisions, is_signed);
+                compressor.push_stripe(buf, stripe_heights, nullptr, nullptr, nullptr, precisions, is_signed);
             }
             else if (img->bps == 8){
                 kdu_byte *buf = (kdu_byte *) img->pixels;

--- a/src/formats/SipiIOJpeg.cpp
+++ b/src/formats/SipiIOJpeg.cpp
@@ -126,10 +126,10 @@ namespace Sipi {
 
         delete [] file_buffer->buffer;
         delete file_buffer;
-        cinfo->client_data = NULL;
+        cinfo->client_data = nullptr;
 
         free(cinfo->dest);
-        cinfo->dest = NULL;
+        cinfo->dest = nullptr;
     }
     //=============================================================================
 
@@ -209,9 +209,9 @@ namespace Sipi {
 
         delete[] file_buffer->buffer;
         delete file_buffer;
-        cinfo->client_data = NULL;
+        cinfo->client_data = nullptr;
         free(cinfo->src);
-        cinfo->src = NULL;
+        cinfo->src = nullptr;
     }
     //=============================================================================
 
@@ -289,10 +289,10 @@ namespace Sipi {
 
         free(html_buffer->buffer);
         free(html_buffer);
-        cinfo->client_data = NULL;
+        cinfo->client_data = nullptr;
 
         free(cinfo->dest);
-        cinfo->dest = NULL;
+        cinfo->dest = nullptr;
     }
     //=============================================================================
 
@@ -363,18 +363,18 @@ namespace Sipi {
             switch(id) {
                 case 0x0404: { // IPTC data
                     //cerr << ">>> Photoshop: IPTC" << endl;
-                    if (img->iptc == NULL) img->iptc = new SipiIptc((unsigned char *) ptr, datalen);
+                    if (img->iptc == nullptr) img->iptc = new SipiIptc((unsigned char *) ptr, datalen);
                     // IPTC – handled separately!
                     break;
                 }
                 case 0x040f: { // ICC data
                     //cerr << ">>> Photoshop: ICC" << endl;
                     // ICC profile
-                    if (img->icc == NULL) img->icc = new SipiIcc((unsigned char *) ptr, datalen);
+                    if (img->icc == nullptr) img->icc = new SipiIcc((unsigned char *) ptr, datalen);
                     break;
                 }
                 case 0x0422: { // EXIF data
-                    if (img->exif == NULL) img->exif = new SipiExif((unsigned char *) ptr, datalen);
+                    if (img->exif == nullptr) img->exif = new SipiExif((unsigned char *) ptr, datalen);
                     //cerr << ">>> Photoshop: EXIF" << endl;
                     // exif
                     break;
@@ -382,7 +382,7 @@ namespace Sipi {
                 case 0x0424: { // XMP data
                     //cerr << ">>> Photoshop: XMP" << endl;
                     // XMP data
-                    if (img->xmp == NULL)img->xmp = new SipiXmp(ptr, datalen);
+                    if (img->xmp == nullptr)img->xmp = new SipiXmp(ptr, datalen);
                 }
                 default: {
                     // URL
@@ -450,7 +450,7 @@ namespace Sipi {
         struct jpeg_error_mgr jerr;
 
 
-        JSAMPARRAY linbuf = NULL;
+        JSAMPARRAY linbuf = nullptr;
         jpeg_saved_marker_ptr marker;
 
         //
@@ -501,7 +501,7 @@ namespace Sipi {
         // getting Metadata
         //
         marker = cinfo.marker_list;
-        unsigned char *icc_buffer = NULL;
+        unsigned char *icc_buffer = nullptr;
         int icc_buffer_len = 0;
         while (marker) {
             //fprintf(stderr, "#######################################################################\n");
@@ -515,7 +515,7 @@ namespace Sipi {
                 // first we try to find the exif part
                 //
                 unsigned char *pos = (unsigned char *) memmem(marker->data, marker->data_length, "Exif\000\000", 6);
-                if (pos != NULL) {
+                if (pos != nullptr) {
                     img->exif = new SipiExif(pos + 6, marker->data_length - (pos - marker->data) - 6);
                 }
 
@@ -523,7 +523,7 @@ namespace Sipi {
                 // first we try to find the xmp part: TODO: reading XMP which spans multiple segments. See ExtendedXMP !!!
                 //
                 pos = (unsigned char *) memmem(marker->data, marker->data_length, "http://ns.adobe.com/xap/1.0/\000", 29);
-                if (pos != NULL) {
+                if (pos != nullptr) {
                     char start[] = {'<', '?', 'x', 'p', 'a', 'c', 'k', 'e', 't', ' ', 'b', 'e', 'g', 'i', 'n', '\0'};
                     char end[] = {'<', '?', 'x', 'p', 'a', 'c', 'k', 'e', 't', ' ', 'e', 'n', 'd', '\0'};
 
@@ -582,7 +582,7 @@ namespace Sipi {
                 // first we try to find the exif part
                 //
                 unsigned char *pos = (unsigned char *) memmem(marker->data, marker->data_length, "ICC_PROFILE\0", 12);
-                if (pos != NULL) {
+                if (pos != nullptr) {
                     int len = marker->data_length - (pos - (unsigned char *) marker->data) - 14;
                     icc_buffer = (unsigned char *) realloc(icc_buffer, icc_buffer_len + len);
                     Sipi::memcpy (icc_buffer + icc_buffer_len, pos + 14, (size_t) len);
@@ -599,7 +599,7 @@ namespace Sipi {
             }
             marker = marker->next;
         }
-        if (icc_buffer != NULL) {
+        if (icc_buffer != nullptr) {
             img->icc = new SipiIcc(icc_buffer, icc_buffer_len);
         }
 
@@ -681,14 +681,14 @@ namespace Sipi {
         //
         // do some croping...
         //
-        if ((region != NULL) && (region->getType()) != SipiRegion::FULL) {
+        if ((region != nullptr) && (region->getType()) != SipiRegion::FULL) {
             (void) img->crop(region);
         }
 
         //
         // resize/Scale the image if necessary
         //
-        if ((size != NULL) && (size->getType() != SipiSize::FULL)) {
+        if ((size != nullptr) && (size->getType() != SipiSize::FULL)) {
             int nnx, nny, reduce;
             bool redonly;
             SipiSize::SizeType rtype = size->get_size(img->nx, img->ny, nnx, nny, reduce, redonly);
@@ -716,7 +716,7 @@ namespace Sipi {
         //
         // open the input file
         //
-        if ((infile = fopen (filepath.c_str(), "rb")) == NULL) {
+        if ((infile = fopen (filepath.c_str(), "rb")) == nullptr) {
             // inlock.unlock();
             return false;
         }
@@ -888,7 +888,7 @@ namespace Sipi {
         //!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
         //
 
-        if (img->exif != NULL) {
+        if (img->exif != nullptr) {
             unsigned int len;
             unsigned char *buf = img->exif->exifBytes(len);
             char start[] = "Exif\000\000";
@@ -911,7 +911,7 @@ namespace Sipi {
             delete [] exifchunk;
         }
 
-        if (img->xmp != NULL) {
+        if (img->xmp != nullptr) {
             unsigned int len;
             const char *buf;
             try {
@@ -939,7 +939,7 @@ namespace Sipi {
             delete [] xmpchunk;
         }
 
-        if (img->icc != NULL) {
+        if (img->icc != nullptr) {
             unsigned int len;
             const unsigned char *buf = img->icc->iccBytes(len);
             unsigned char start[14] = {0x49, 0x43, 0x43, 0x5F, 0x50, 0x52, 0x4F, 0x46, 0x49, 0x4C, 0x45, 0x0}; //"ICC_PROFILE\000";
@@ -979,7 +979,7 @@ namespace Sipi {
             }
         }
 
-        if (img->iptc != NULL) {
+        if (img->iptc != nullptr) {
             unsigned int len;
             const unsigned char *buf = img->iptc->iptcBytes(len);
             char start[] = "Photoshop 3.0\0008BIM\004\004\000\000";

--- a/src/formats/SipiIOOpenJ2k.cpp
+++ b/src/formats/SipiIOOpenJ2k.cpp
@@ -70,7 +70,7 @@ namespace Sipi {
 
 
 
-    bool SipiIOOpenJ2k::read(SipiImage *img, string filepath, SipiRegion *region, SipiSize *size)
+    bool SipiIOOpenJ2k::read(SipiImage *img, string filepath, std::shared_ptr<SipiRegion> region, std::shared_ptr<SipiSize> size)
     {
         auto logger = Logger::getLogger(shttps::loggername);
         FILE *reader;

--- a/src/formats/SipiIOOpenJ2k.cpp
+++ b/src/formats/SipiIOOpenJ2k.cpp
@@ -80,7 +80,7 @@ namespace Sipi {
 
         opj_set_default_decoder_parameters(&parameters);
 
-        if ((reader = fopen(filepath.c_str(), "rb")) == NULL) {
+        if ((reader = fopen(filepath.c_str(), "rb")) == nullptr) {
             throw SipiError(__file__, __LINE__, "Couldn't open input file!", errno);
         };
         unsigned char buf[12];
@@ -147,7 +147,7 @@ namespace Sipi {
             throw SipiError(__file__, __LINE__, "OpenJPEG2000: failed to setup the decoder!");
         }
 
-        opj_image_t *image = NULL;
+        opj_image_t *image = nullptr;
         /* Read the main header of the codestream and if necessary the JP2 boxes*/
         if(! opj_read_header(l_stream, l_codec, &image)){
             opj_stream_destroy(l_stream);
@@ -169,7 +169,7 @@ namespace Sipi {
         // is there a region of interest defined ? If yes, get the cropping parameters...
         //
         bool do_roi = false;
-        if ((region != NULL) && (region->getType()) != SipiRegion::FULL) {
+        if ((region != nullptr) && (region->getType()) != SipiRegion::FULL) {
             int x, y, nx, ny;
             try {
                 region->crop_coords(__nx, __ny, x, y, nx, ny);

--- a/src/formats/SipiIOPng.cpp
+++ b/src/formats/SipiIOPng.cpp
@@ -121,7 +121,7 @@ namespace Sipi {
         //
         // open the input file
         //
-        if ((infile = fopen (filepath.c_str(), "rb")) == NULL) {
+        if ((infile = fopen (filepath.c_str(), "rb")) == nullptr) {
             return FALSE;
         }
         fread(header, 1, 8, infile);
@@ -130,15 +130,15 @@ namespace Sipi {
             return FALSE; // it's not a PNG file
         }
 
-        if ((png_ptr = png_create_read_struct (PNG_LIBPNG_VER_STRING, (png_voidp) NULL, (png_error_ptr) NULL, (png_error_ptr) NULL)) == NULL) {
+        if ((png_ptr = png_create_read_struct (PNG_LIBPNG_VER_STRING, (png_voidp) nullptr, (png_error_ptr) nullptr, (png_error_ptr) nullptr)) == nullptr) {
             fclose (infile);
             throw SipiImageError(__file__, __LINE__, "Error reading PNG file \"" + filepath + "\": Could not allocate mempry fpr png_structp !");
         }
-        if ((info_ptr = png_create_info_struct(png_ptr)) == NULL) {
+        if ((info_ptr = png_create_info_struct(png_ptr)) == nullptr) {
             fclose (infile);
             throw SipiImageError(__file__, __LINE__, "Error reading PNG file \"" + filepath + "\": Could not allocate mempry fpr png_infop !");
         }
-        if ((end_info = png_create_info_struct(png_ptr)) == NULL) {
+        if ((end_info = png_create_info_struct(png_ptr)) == nullptr) {
             fclose (infile);
             throw SipiImageError(__file__, __LINE__, "Error reading PNG file \"" + filepath + "\": Could not allocate mempry fpr png_infop !");
         }
@@ -193,7 +193,7 @@ namespace Sipi {
         }
 
         png_text *png_texts;
-        int num_comments = png_get_text(png_ptr, info_ptr, &png_texts, NULL);
+        int num_comments = png_get_text(png_ptr, info_ptr, &png_texts, nullptr);
         for (int i = 0; i < num_comments; i++) {
             if (strcmp(png_texts[i].key, xmp_tag) == 0) {
                 img->xmp = new SipiXmp((char *) png_texts[i].text, (int) png_texts[i].text_length);
@@ -246,14 +246,14 @@ namespace Sipi {
 
         fclose(infile);
 
-        if (region != NULL) { //we just use the image.crop method
+        if (region != nullptr) { //we just use the image.crop method
             (void) img->crop(region);
         }
 
         //
         // resize/Scale the image if necessary
         //
-        if (size != NULL) {
+        if (size != nullptr) {
             int nnx, nny, reduce;
             bool redonly;
             SipiSize::SizeType rtype = size->get_size(img->nx, img->ny, nnx, nny, reduce, redonly);
@@ -280,7 +280,7 @@ namespace Sipi {
         //
         // open the input file
         //
-        if ((infile = fopen (filepath.c_str(), "rb")) == NULL) {
+        if ((infile = fopen (filepath.c_str(), "rb")) == nullptr) {
             return FALSE;
         }
         fread(header, 1, 8, infile);
@@ -293,15 +293,15 @@ namespace Sipi {
         png_infop info_ptr;
         png_infop end_info;
 
-        if ((png_ptr = png_create_read_struct (PNG_LIBPNG_VER_STRING, (png_voidp) NULL, (png_error_ptr) NULL, (png_error_ptr) NULL)) == NULL) {
+        if ((png_ptr = png_create_read_struct (PNG_LIBPNG_VER_STRING, (png_voidp) nullptr, (png_error_ptr) nullptr, (png_error_ptr) nullptr)) == nullptr) {
             fclose (infile);
             throw SipiImageError(__file__, __LINE__, "Error reading PNG file \"" + filepath + "\": Could not allocate mempry fpr png_structp !");
         }
-        if ((info_ptr = png_create_info_struct(png_ptr)) == NULL) {
+        if ((info_ptr = png_create_info_struct(png_ptr)) == nullptr) {
             fclose (infile);
             throw SipiImageError(__file__, __LINE__, "Error reading PNG file \"" + filepath + "\": Could not allocate mempry fpr png_infop !");
         }
-        if ((end_info = png_create_info_struct(png_ptr)) == NULL) {
+        if ((end_info = png_create_info_struct(png_ptr)) == nullptr) {
             fclose (infile);
             throw SipiImageError(__file__, __LINE__, "Error reading PNG file \"" + filepath + "\": Could not allocate mempry fpr png_infop !");
         }
@@ -328,7 +328,7 @@ namespace Sipi {
         chunk->text_length = len;
         chunk->itxt_length = 0;
         chunk->lang = lang_en;
-        chunk->lang_key = NULL;
+        chunk->lang_key = nullptr;
     }
     /*==========================================================================*/
 
@@ -356,10 +356,10 @@ namespace Sipi {
     /*==========================================================================*/
 
     void SipiIOPng::write(SipiImage *img, std::string filepath, int quality) {
-        FILE *outfile = NULL;
+        FILE *outfile = nullptr;
         png_structp png_ptr;
 
-        if (!(png_ptr = png_create_write_struct(PNG_LIBPNG_VER_STRING, NULL, NULL, NULL))) {
+        if (!(png_ptr = png_create_write_struct(PNG_LIBPNG_VER_STRING, nullptr, nullptr, nullptr))) {
             throw SipiImageError(__file__, __LINE__, "Error writing PNG file \"" + filepath + "\": png_create_write_struct failed !");
         }
 
@@ -393,7 +393,7 @@ namespace Sipi {
             throw SipiImageError(__file__, __LINE__, "Error writing PNG file \"" + filepath + "\": png_create_info_struct !");
         }
 
-    	if (outfile != NULL) png_init_io(png_ptr, outfile);
+    	if (outfile != nullptr) png_init_io(png_ptr, outfile);
 
     	png_set_filter(png_ptr, 0, PNG_FILTER_NONE);
 
@@ -423,7 +423,7 @@ namespace Sipi {
         // ICC profile handfling is special...
         //
         unsigned char *icc_buf;
-        if (img->icc != NULL) {
+        if (img->icc != nullptr) {
             unsigned int len;
             icc_buf = img->icc->iccBytes(len);
             png_set_iCCP(png_ptr, info_ptr, "ICC", PNG_COMPRESSION_TYPE_BASE, icc_buf, len);
@@ -433,22 +433,22 @@ namespace Sipi {
         //
         // other metadata comes here
         //
-        unsigned char *exif_buf = NULL;
+        unsigned char *exif_buf = nullptr;
         if (img->exif) {
             unsigned int len;
             exif_buf = img->exif->exifBytes(len);
             chunk_ptr.add_zTXt(exif_tag, (char *) exif_buf, len);
         }
 
-        unsigned char *iptc_buf = NULL;
+        unsigned char *iptc_buf = nullptr;
         if (img->iptc) {
             unsigned int len;
             iptc_buf = img->iptc->iptcBytes(len);
             chunk_ptr.add_zTXt(iptc_tag, (char *) iptc_buf, len);
         }
 
-        char *xmp_buf = NULL;
-        if (img->xmp != NULL) {
+        char *xmp_buf = nullptr;
+        if (img->xmp != nullptr) {
             unsigned int len;
             xmp_buf = img->xmp->xmpBytes(len);
             chunk_ptr.add_iTXt(xmp_tag, xmp_buf, len);
@@ -484,19 +484,19 @@ namespace Sipi {
         png_set_rows(png_ptr, info_ptr, row_pointers);
 
         png_write_info(png_ptr, info_ptr);
-        png_write_png(png_ptr, info_ptr, PNG_TRANSFORM_SWAP_ENDIAN, NULL); // we expect the data to be little endian...
+        png_write_png(png_ptr, info_ptr, PNG_TRANSFORM_SWAP_ENDIAN, nullptr); // we expect the data to be little endian...
         png_write_end(png_ptr, info_ptr);
 
         png_free (png_ptr, row_pointers);
 
         png_free_data(png_ptr, info_ptr, PNG_FREE_ALL, -1);
 
-        if (icc_buf != NULL) delete[] icc_buf;
-        if (exif_buf != NULL) delete[] exif_buf;
-        if (iptc_buf != NULL) delete[] iptc_buf;
-        if (xmp_buf != NULL) delete[] xmp_buf;
+        if (icc_buf != nullptr) delete[] icc_buf;
+        if (exif_buf != nullptr) delete[] exif_buf;
+        if (iptc_buf != nullptr) delete[] iptc_buf;
+        if (xmp_buf != nullptr) delete[] xmp_buf;
 
-        if (outfile != NULL) fclose(outfile);
+        if (outfile != nullptr) fclose(outfile);
     };
 
 }

--- a/src/formats/SipiIOTiff.cpp
+++ b/src/formats/SipiIOTiff.cpp
@@ -62,12 +62,12 @@ extern "C" {
     static MEMTIFF *memTiffOpen(tsize_t incsiz = 10240, tsize_t initsiz = 10240)
     {
         MEMTIFF *memtif;
-        if ((memtif = (MEMTIFF *) malloc(sizeof(MEMTIFF))) == NULL) {
+        if ((memtif = (MEMTIFF *) malloc(sizeof(MEMTIFF))) == nullptr) {
             throw Sipi::SipiImageError(__file__, __LINE__, "malloc failed", errno);
         }
         memtif->incsiz = incsiz;
         if (initsiz == 0) initsiz = incsiz;
-        if ((memtif->data = (unsigned char *) malloc(initsiz*sizeof(unsigned char))) == NULL) {
+        if ((memtif->data = (unsigned char *) malloc(initsiz*sizeof(unsigned char))) == nullptr) {
             free (memtif);
             throw Sipi::SipiImageError(__file__, __LINE__, "malloc failed", errno);
         }
@@ -99,7 +99,7 @@ extern "C" {
     {
         MEMTIFF *memtif = (MEMTIFF *) handle;
         if (((tsize_t) memtif->fptr + size) > memtif->size) {
-            if ((memtif->data = (unsigned char *) realloc(memtif->data, memtif->fptr + memtif->incsiz + size)) == NULL) {
+            if ((memtif->data = (unsigned char *) realloc(memtif->data, memtif->fptr + memtif->incsiz + size)) == nullptr) {
                 throw Sipi::SipiImageError(__file__, __LINE__, "realloc failed", errno);
             }
             memtif->size = memtif->fptr + memtif->incsiz + size;
@@ -118,7 +118,7 @@ extern "C" {
         switch (whence) {
             case SEEK_SET: {
                 if ((tsize_t) off > memtif->size) {
-                    if ((memtif->data = (unsigned char *) realloc(memtif->data, memtif->size + memtif->incsiz + off)) == NULL) {
+                    if ((memtif->data = (unsigned char *) realloc(memtif->data, memtif->size + memtif->incsiz + off)) == nullptr) {
                         throw Sipi::SipiImageError(__file__, __LINE__, "realloc failed", errno);
                     }
                     memtif->size = memtif->size + memtif->incsiz + off;
@@ -128,7 +128,7 @@ extern "C" {
             }
             case SEEK_CUR: {
                 if ((tsize_t)(memtif->fptr + off) > memtif->size) {
-                    if ((memtif->data = (unsigned char *) realloc(memtif->data, memtif->fptr + memtif->incsiz + off)) == NULL) {
+                    if ((memtif->data = (unsigned char *) realloc(memtif->data, memtif->fptr + memtif->incsiz + off)) == nullptr) {
                         throw Sipi::SipiImageError(__file__, __LINE__, "realloc failed", errno);
                     }
                     memtif->size = memtif->fptr + memtif->incsiz + off;
@@ -138,7 +138,7 @@ extern "C" {
             }
             case SEEK_END: {
                 if ((tsize_t) (memtif->size + off) > memtif->size) {
-                    if ((memtif->data = (unsigned char *) realloc(memtif->data, memtif->size + memtif->incsiz + off)) == NULL) {
+                    if ((memtif->data = (unsigned char *) realloc(memtif->data, memtif->size + memtif->incsiz + off)) == nullptr) {
                         throw Sipi::SipiImageError(__file__, __LINE__, "realloc failed", errno);
                     }
                     memtif->size = memtif->size + memtif->incsiz + off;
@@ -186,10 +186,10 @@ extern "C" {
 
     static void memTiffFree(MEMTIFF *memtif)
     {
-        if (memtif->data != NULL) free(memtif->data);
-        memtif->data = NULL;
-        if (memtif != NULL) free(memtif);
-        memtif = NULL;
+        if (memtif->data != nullptr) free(memtif->data);
+        memtif->data = nullptr;
+        if (memtif != nullptr) free(memtif);
+        memtif = nullptr;
         return;
     }
     /*===========================================================================*/
@@ -310,8 +310,8 @@ namespace Sipi {
 
         nx = 0;
         ny = 0;
-        if (NULL == (tif = TIFFOpen(wmfile.c_str(), "r"))) {
-            return NULL;
+        if (nullptr == (tif = TIFFOpen(wmfile.c_str(), "r"))) {
+            return nullptr;
         }
 
         // add EXIF tags to the set of tags that libtiff knows about
@@ -403,12 +403,12 @@ namespace Sipi {
     };
     //============================================================================
 
-    static TIFFExtendProc parent_extender = NULL;
+    static TIFFExtendProc parent_extender = nullptr;
 
     static void registerCustomTIFFTags(TIFF *tif) {
         /* Install the extended Tag field info */
         TIFFMergeFieldInfo(tif, xtiffFieldInfo, N(xtiffFieldInfo));
-        if (parent_extender != NULL) (*parent_extender)(tif);
+        if (parent_extender != nullptr) (*parent_extender)(tif);
     }
     //============================================================================
 
@@ -427,7 +427,7 @@ namespace Sipi {
     {
     	TIFF *tif;
 
-        if (NULL != (tif = TIFFOpen (filepath.c_str(), "r"))) {
+        if (nullptr != (tif = TIFFOpen (filepath.c_str(), "r"))) {
             TIFFSetErrorHandler(tiffError);
             TIFFSetWarningHandler(tiffWarning);
 
@@ -436,7 +436,7 @@ namespace Sipi {
             //
             uint16 safo, ori, planar, stmp;
 
-            (void) TIFFSetWarningHandler(NULL);
+            (void) TIFFSetWarningHandler(nullptr);
 
             if (TIFFGetField (tif, TIFFTAG_IMAGEWIDTH, &(img->nx)) == 0) {
                 TIFFClose(tif);
@@ -476,39 +476,39 @@ namespace Sipi {
             //
             char *str;
             if (1 == TIFFGetField(tif, TIFFTAG_IMAGEDESCRIPTION, &str)) {
-                if (img->exif == NULL) img->exif = new SipiExif();
+                if (img->exif == nullptr) img->exif = new SipiExif();
                 img->exif->addKeyVal(std::string("Exif.Image.ImageDescription"), std::string(str));
             }
             if (1 == TIFFGetField(tif, TIFFTAG_MAKE, &str)) {
-                if (img->exif == NULL) img->exif = new SipiExif();
+                if (img->exif == nullptr) img->exif = new SipiExif();
                 img->exif->addKeyVal(std::string("Exif.Image.Make"), std::string(str));
             }
             if (1 == TIFFGetField(tif, TIFFTAG_MODEL, &str)) {
-                if (img->exif == NULL) img->exif = new SipiExif();
+                if (img->exif == nullptr) img->exif = new SipiExif();
                 img->exif->addKeyVal(std::string("Exif.Image.Model"), std::string(str));
             }
             if (1 == TIFFGetField(tif, TIFFTAG_SOFTWARE, &str)) {
-                if (img->exif == NULL) img->exif = new SipiExif();
+                if (img->exif == nullptr) img->exif = new SipiExif();
                 img->exif->addKeyVal(std::string("Exif.Image.Software"), std::string(str));
             }
             if (1 == TIFFGetField(tif, TIFFTAG_DATETIME, &str)) {
-                if (img->exif == NULL) img->exif = new SipiExif();
+                if (img->exif == nullptr) img->exif = new SipiExif();
                 img->exif->addKeyVal(std::string("Exif.Image.DateTime"), std::string(str));
             }
             if (1 == TIFFGetField(tif, TIFFTAG_ARTIST, &str)) {
-                if (img->exif == NULL) img->exif = new SipiExif();
+                if (img->exif == nullptr) img->exif = new SipiExif();
                 img->exif->addKeyVal(std::string("Exif.Image.Artist"), std::string(str));
             }
             if (1 == TIFFGetField(tif, TIFFTAG_HOSTCOMPUTER, &str)) {
-                if (img->exif == NULL) img->exif = new SipiExif();
+                if (img->exif == nullptr) img->exif = new SipiExif();
                 img->exif->addKeyVal(std::string("Exif.Image.HostComputer"), std::string(str));
             }
             if (1 == TIFFGetField(tif, TIFFTAG_COPYRIGHT, &str)) {
-                if (img->exif == NULL) img->exif = new SipiExif();
+                if (img->exif == nullptr) img->exif = new SipiExif();
                 img->exif->addKeyVal(std::string("Exif.Image.Copyright"), std::string(str));
             }
             if (1 == TIFFGetField(tif, TIFFTAG_DOCUMENTNAME, &str)) {
-                if (img->exif == NULL) img->exif = new SipiExif();
+                if (img->exif == nullptr) img->exif = new SipiExif();
                 img->exif->addKeyVal(std::string("Exif.Image.DocumentName"), std::string(str));
             }
 
@@ -527,17 +527,17 @@ namespace Sipi {
 */
             float f;
             if (1 == TIFFGetField(tif, TIFFTAG_XRESOLUTION, &f)) {
-                if (img->exif == NULL) img->exif = new SipiExif();
+                if (img->exif == nullptr) img->exif = new SipiExif();
                 img->exif->addKeyVal(std::string("Exif.Image.XResolution"), f);
             }
             if (1 == TIFFGetField(tif, TIFFTAG_YRESOLUTION, &f)) {
-                if (img->exif == NULL) img->exif = new SipiExif();
+                if (img->exif == nullptr) img->exif = new SipiExif();
                 img->exif->addKeyVal(std::string("Exif.Image.YResolution"), f);
             }
 
             short s;
         	if (1 == TIFFGetField(tif, TIFFTAG_RESOLUTIONUNIT, &s)) {
-                if (img->exif == NULL) img->exif = new SipiExif();
+                if (img->exif == nullptr) img->exif = new SipiExif();
                 img->exif->addKeyVal(std::string("Exif.Image.ResolutionUnit"), s);
         	}
 
@@ -546,7 +546,7 @@ namespace Sipi {
             // read iptc header
             //
             unsigned int iptc_length = 0;
-            unsigned char *iptc_content = NULL;
+            unsigned char *iptc_content = nullptr;
 
             if (TIFFGetField(tif, TIFFTAG_RICHTIFFIPTC, &iptc_length, &iptc_content) != 0) {
                 try {
@@ -563,7 +563,7 @@ namespace Sipi {
             //
             toff_t exif_ifd_offs;
             if (1 == TIFFGetField(tif, TIFFTAG_EXIFIFD, &exif_ifd_offs)) {
-                if (img->exif == NULL) img->exif = new SipiExif();
+                if (img->exif == nullptr) img->exif = new SipiExif();
                 readExif(img, tif, exif_ifd_offs);
             }
 
@@ -571,7 +571,7 @@ namespace Sipi {
             // read xmp header
             //
             int xmp_length;
-            char *xmp_content = NULL;
+            char *xmp_content = nullptr;
             if (1 == TIFFGetField(tif, TIFFTAG_XMLPACKET, &xmp_length, &xmp_content)) {
                 try {
                     img->xmp = new SipiXmp(xmp_content, xmp_length);
@@ -587,7 +587,7 @@ namespace Sipi {
             //
             unsigned int icc_len;
             unsigned char *icc_buf;
-            float *whitepoint = NULL;
+            float *whitepoint = nullptr;
             if (1 == TIFFGetField(tif, TIFFTAG_ICCPROFILE, &icc_len, &icc_buf)) {
                 try {
                     img->icc = new SipiIcc(icc_buf, icc_len);
@@ -600,7 +600,7 @@ namespace Sipi {
                 //
                 // Wow, we have TIFF colormetry..... Who is still using this???
                 //
-                float *primaries_ti = NULL;
+                float *primaries_ti = nullptr;
                 float primaries[6];
                 if (1 == TIFFGetField(tif, TIFFTAG_PRIMARYCHROMATICITIES, &primaries_ti)) {
                     primaries[0] = primaries_ti[0];
@@ -636,11 +636,11 @@ namespace Sipi {
                     }
                 }
                 else {
-                    tfunc = NULL;
+                    tfunc = nullptr;
                     tfunc_len = 0;
                 }
                 img->icc = new SipiIcc(whitepoint, primaries, tfunc, tfunc_len);
-                if (tfunc != NULL) delete [] tfunc;
+                if (tfunc != nullptr) delete [] tfunc;
             }
 
             //
@@ -653,7 +653,7 @@ namespace Sipi {
             }
 
 
-            if ((region == NULL) || (region->getType() == SipiRegion::FULL)) {
+            if ((region == nullptr) || (region->getType() == SipiRegion::FULL)) {
                 if (planar == PLANARCONFIG_CONTIG) {
                     uint32 i;
                     uint8 *dataptr = new uint8[img->ny*sll];
@@ -748,7 +748,7 @@ namespace Sipi {
 
             TIFFClose(tif);
 
-            if (img->icc == NULL) {
+            if (img->icc == nullptr) {
                 switch(img->photo) {
                     case MINISBLACK: {
                         if (img->bps == 1) {
@@ -816,7 +816,7 @@ namespace Sipi {
             //
             // resize/Scale the image if necessary
             //
-            if (size != NULL) {
+            if (size != nullptr) {
                 int nnx, nny, reduce;
                 bool redonly;
                 SipiSize::SizeType rtype = size->get_size(img->nx, img->ny, nnx, nny, reduce, redonly);
@@ -841,12 +841,12 @@ namespace Sipi {
     bool SipiIOTiff::getDim(std::string filepath, int &width, int &height) {
     	TIFF *tif;
 
-        if (NULL != (tif = TIFFOpen (filepath.c_str(), "r"))) {
+        if (nullptr != (tif = TIFFOpen (filepath.c_str(), "r"))) {
 
             //
             // OK, it's a TIFF file
             //
-            (void) TIFFSetWarningHandler(NULL);
+            (void) TIFFSetWarningHandler(nullptr);
 
             if (TIFFGetField (tif, TIFFTAG_IMAGEWIDTH, &width) == 0) {
                 std::cerr << "TIFF image file " << filepath << ": Error getting TIFFTAG_IMAGEWIDTH" << std::endl;
@@ -870,7 +870,7 @@ namespace Sipi {
     void SipiIOTiff::write(SipiImage *img, std::string filepath, int quality)
     {
         TIFF *tif;
-        MEMTIFF *memtif = NULL;
+        MEMTIFF *memtif = nullptr;
         uint32 rowsperstrip = (uint32) -1;
 
         if ((filepath == "stdout:") || (filepath == "HTTP")) {
@@ -886,8 +886,8 @@ namespace Sipi {
             );
         }
         else {
-            if ((tif = TIFFOpen (filepath.c_str(), "w")) == NULL) {
-                if (memtif != NULL) memTiffFree(memtif);
+            if ((tif = TIFFOpen (filepath.c_str(), "w")) == nullptr) {
+                if (memtif != nullptr) memTiffFree(memtif);
                 std::string msg = "TIFFopen of \"" + filepath + "\" failed!";
                 throw Sipi::SipiImageError(__file__, __LINE__, msg);
             }
@@ -938,7 +938,7 @@ namespace Sipi {
         //
         // let's get the TIFF metadata if there is some. We stored the TIFF metadata in the exifData meber variable!
         //
-        if ((img->exif != NULL) & (!(img->skip_metadata & SKIP_EXIF))) {
+        if ((img->exif != nullptr) & (!(img->skip_metadata & SKIP_EXIF))) {
             std::string value;
             if (img->exif->getValByKey("Exif.Image.ImageDescription", value)) {
                 TIFFSetField(tif, TIFFTAG_IMAGEDESCRIPTION, value.c_str());
@@ -980,7 +980,7 @@ namespace Sipi {
             }
         }
 
-        if ((img->icc != NULL) & (!(img->skip_metadata & SKIP_ICC))) {
+        if ((img->icc != nullptr) & (!(img->skip_metadata & SKIP_ICC))) {
             unsigned int len;
             const unsigned char *buf;
             try {
@@ -997,7 +997,7 @@ namespace Sipi {
         //
         // write IPTC data, if available
         //
-        if ((img->iptc != NULL) & (!(img->skip_metadata & SKIP_IPTC))) {
+        if ((img->iptc != nullptr) & (!(img->skip_metadata & SKIP_IPTC))) {
             unsigned int len;
             unsigned char *buf;
             try {
@@ -1016,7 +1016,7 @@ namespace Sipi {
         //
         // write XMP data
         //
-        if ((img->xmp != NULL) & (!(img->skip_metadata & SKIP_XMP))) {
+        if ((img->xmp != nullptr) & (!(img->skip_metadata & SKIP_XMP))) {
             unsigned int len;
             const char *buf;
             try {
@@ -1057,7 +1057,7 @@ namespace Sipi {
         //
         // write exif data
         //
-        if (img->exif != NULL) {
+        if (img->exif != nullptr) {
             TIFFWriteDirectory(tif);
             writeExif(img, tif);
         }
@@ -1065,7 +1065,7 @@ namespace Sipi {
 
         TIFFClose(tif);
 
-        if (memtif != NULL) {
+        if (memtif != nullptr) {
             if (filepath == "stdout:") {
                 size_t n = 0;
                 while (n < memtif->flen) {
@@ -1128,7 +1128,7 @@ namespace Sipi {
                         break;
                     }
                     case EXIF_DT_STRING: {
-                        char *tmpstr = NULL;
+                        char *tmpstr = nullptr;
                         if (TIFFGetField (tif, exiftag_list[i].tag_id, &tmpstr)) {
                             img->exif->addKeyVal(exiftag_list[i].tag_id, "Photo", tmpstr);
                         }

--- a/src/formats/SipiIOTiff.cpp
+++ b/src/formats/SipiIOTiff.cpp
@@ -423,7 +423,7 @@ namespace Sipi {
         }
     }
 
-    bool SipiIOTiff::read(SipiImage *img, std::string filepath, SipiRegion *region, SipiSize *size, bool force_bps_8)
+    bool SipiIOTiff::read(SipiImage *img, std::string filepath, std::shared_ptr<SipiRegion> region, std::shared_ptr<SipiSize> size, bool force_bps_8)
     {
     	TIFF *tif;
 
@@ -476,39 +476,39 @@ namespace Sipi {
             //
             char *str;
             if (1 == TIFFGetField(tif, TIFFTAG_IMAGEDESCRIPTION, &str)) {
-                if (img->exif == nullptr) img->exif = new SipiExif();
+                img->ensure_exif();
                 img->exif->addKeyVal(std::string("Exif.Image.ImageDescription"), std::string(str));
             }
             if (1 == TIFFGetField(tif, TIFFTAG_MAKE, &str)) {
-                if (img->exif == nullptr) img->exif = new SipiExif();
+                img->ensure_exif();
                 img->exif->addKeyVal(std::string("Exif.Image.Make"), std::string(str));
             }
             if (1 == TIFFGetField(tif, TIFFTAG_MODEL, &str)) {
-                if (img->exif == nullptr) img->exif = new SipiExif();
+                img->ensure_exif();
                 img->exif->addKeyVal(std::string("Exif.Image.Model"), std::string(str));
             }
             if (1 == TIFFGetField(tif, TIFFTAG_SOFTWARE, &str)) {
-                if (img->exif == nullptr) img->exif = new SipiExif();
+                img->ensure_exif();
                 img->exif->addKeyVal(std::string("Exif.Image.Software"), std::string(str));
             }
             if (1 == TIFFGetField(tif, TIFFTAG_DATETIME, &str)) {
-                if (img->exif == nullptr) img->exif = new SipiExif();
+                img->ensure_exif();
                 img->exif->addKeyVal(std::string("Exif.Image.DateTime"), std::string(str));
             }
             if (1 == TIFFGetField(tif, TIFFTAG_ARTIST, &str)) {
-                if (img->exif == nullptr) img->exif = new SipiExif();
+                img->ensure_exif();
                 img->exif->addKeyVal(std::string("Exif.Image.Artist"), std::string(str));
             }
             if (1 == TIFFGetField(tif, TIFFTAG_HOSTCOMPUTER, &str)) {
-                if (img->exif == nullptr) img->exif = new SipiExif();
+                img->ensure_exif();
                 img->exif->addKeyVal(std::string("Exif.Image.HostComputer"), std::string(str));
             }
             if (1 == TIFFGetField(tif, TIFFTAG_COPYRIGHT, &str)) {
-                if (img->exif == nullptr) img->exif = new SipiExif();
+                img->ensure_exif();
                 img->exif->addKeyVal(std::string("Exif.Image.Copyright"), std::string(str));
             }
             if (1 == TIFFGetField(tif, TIFFTAG_DOCUMENTNAME, &str)) {
-                if (img->exif == nullptr) img->exif = new SipiExif();
+                img->ensure_exif();
                 img->exif->addKeyVal(std::string("Exif.Image.DocumentName"), std::string(str));
             }
 
@@ -517,27 +517,27 @@ namespace Sipi {
             //
 /*
             if (1 == TIFFGetField(tif, TIFFTAG_PAGENAME, &str)) {
-                if (img->exif == NULL) img->exif = new SipiExif();
+                if (img->exif == NULL) img->exif = std::make_shared<SipiExif>();
                 img->exif->addKeyVal(string("Exif.Image.PageName"), string(str));
             }
             if (1 == TIFFGetField(tif, TIFFTAG_PAGENUMBER, &str)) {
-                if (img->exif == NULL) img->exif = new SipiExif();
+                if (img->exif == NULL) img->exif = std::make_shared<SipiExif>();
                 img->exif->addKeyVal(string("Exif.Image.PageNumber"), string(str));
             }
 */
             float f;
             if (1 == TIFFGetField(tif, TIFFTAG_XRESOLUTION, &f)) {
-                if (img->exif == nullptr) img->exif = new SipiExif();
+                img->ensure_exif();
                 img->exif->addKeyVal(std::string("Exif.Image.XResolution"), f);
             }
             if (1 == TIFFGetField(tif, TIFFTAG_YRESOLUTION, &f)) {
-                if (img->exif == nullptr) img->exif = new SipiExif();
+                img->ensure_exif();
                 img->exif->addKeyVal(std::string("Exif.Image.YResolution"), f);
             }
 
             short s;
         	if (1 == TIFFGetField(tif, TIFFTAG_RESOLUTIONUNIT, &s)) {
-                if (img->exif == nullptr) img->exif = new SipiExif();
+                img->ensure_exif();
                 img->exif->addKeyVal(std::string("Exif.Image.ResolutionUnit"), s);
         	}
 
@@ -550,7 +550,7 @@ namespace Sipi {
 
             if (TIFFGetField(tif, TIFFTAG_RICHTIFFIPTC, &iptc_length, &iptc_content) != 0) {
                 try {
-                    img->iptc = new SipiIptc(iptc_content, iptc_length);
+                    img->iptc = std::make_shared<SipiIptc>(iptc_content, iptc_length);
                 }
                 catch (SipiError &err) {
                     syslog(LOG_ERR, "%s", err.to_string().c_str());
@@ -563,7 +563,7 @@ namespace Sipi {
             //
             toff_t exif_ifd_offs;
             if (1 == TIFFGetField(tif, TIFFTAG_EXIFIFD, &exif_ifd_offs)) {
-                if (img->exif == nullptr) img->exif = new SipiExif();
+                img->ensure_exif();
                 readExif(img, tif, exif_ifd_offs);
             }
 
@@ -574,7 +574,7 @@ namespace Sipi {
             char *xmp_content = nullptr;
             if (1 == TIFFGetField(tif, TIFFTAG_XMLPACKET, &xmp_length, &xmp_content)) {
                 try {
-                    img->xmp = new SipiXmp(xmp_content, xmp_length);
+                    img->xmp = std::make_shared<SipiXmp>(xmp_content, xmp_length);
                 }
                 catch (SipiError &err) {
                     syslog(LOG_ERR, "%s", err.to_string().c_str());
@@ -590,7 +590,7 @@ namespace Sipi {
             float *whitepoint = nullptr;
             if (1 == TIFFGetField(tif, TIFFTAG_ICCPROFILE, &icc_len, &icc_buf)) {
                 try {
-                    img->icc = new SipiIcc(icc_buf, icc_len);
+                    img->icc = std::make_shared<SipiIcc>(icc_buf, icc_len);
                 }
                 catch (SipiError &err) {
                     syslog(LOG_ERR, "%s", err.to_string().c_str());
@@ -639,7 +639,7 @@ namespace Sipi {
                     tfunc = nullptr;
                     tfunc_len = 0;
                 }
-                img->icc = new SipiIcc(whitepoint, primaries, tfunc, tfunc_len);
+                img->icc = std::make_shared<SipiIcc>(whitepoint, primaries, tfunc, tfunc_len);
                 if (tfunc != nullptr) delete [] tfunc;
             }
 
@@ -754,23 +754,23 @@ namespace Sipi {
                         if (img->bps == 1) {
                             cvrt1BitTo8Bit(img, sll, 0, 255);
                         }
-                        img->icc = new SipiIcc(icc_GRAY_D50);
+                        img->icc = std::make_shared<SipiIcc>(icc_GRAY_D50);
                         break;
                     }
                     case MINISWHITE: {
                         if (img->bps == 1) {
                             cvrt1BitTo8Bit(img, sll, 255, 0);
                         }
-                        img->icc = new SipiIcc(icc_GRAY_D50);
+                        img->icc = std::make_shared<SipiIcc>(icc_GRAY_D50);
                         break;
                     }
                     case SEPARATED: {
-                        img->icc = new SipiIcc(icc_CYMK_standard);
+                        img->icc = std::make_shared<SipiIcc>(icc_CYMK_standard);
                         break;
                     }
                     case YCBCR: // fall through!
                     case RGB: {
-                        img->icc = new SipiIcc(icc_sRGB);
+                        img->icc = std::make_shared<SipiIcc>(icc_sRGB);
                         break;
                     }
                     default: {
@@ -780,7 +780,7 @@ namespace Sipi {
             }
             /*
             if ((img->nc == 3) && (img->photo == PHOTOMETRIC_YCBCR)) {
-                SipiIcc *target_profile = new SipiIcc(img->icc);
+                std::shared_ptr<SipiIcc> target_profile = std::make_shared<SipiIcc>(img->icc);
                 switch (img->bps) {
                     case 8: {
                         img->convertToIcc(target_profile, TYPE_YCbCr_8);
@@ -796,7 +796,7 @@ namespace Sipi {
                 }
             }
             else if ((img->nc == 4) && (img->photo == PHOTOMETRIC_SEPARATED)) { // CMYK image
-                SipiIcc *target_profile = new SipiIcc(icc_sRGB);
+                std::shared_ptr<SipiIcc> target_profile = std::make_shared<SipiIcc>(icc_sRGB);
                 switch (img->bps) {
                     case 8: {
                         img->convertToIcc(target_profile, TYPE_CMYK_8);
@@ -1074,9 +1074,8 @@ namespace Sipi {
                 fflush(stdout);
             }
             else if (filepath == "HTTP") {
-                shttps::Connection *conobj = img->connection();
                 try {
-                    conobj->sendAndFlush(memtif->data, memtif->flen);
+                    img->connection()->sendAndFlush(memtif->data, memtif->flen);
                 }
                 catch (int i) {
                     memTiffFree(memtif);

--- a/src/metadata/SipiExif.cpp
+++ b/src/metadata/SipiExif.cpp
@@ -30,7 +30,7 @@ static const char __file__[] = __FILE__;
 namespace Sipi {
 
     SipiExif::SipiExif() {
-        binaryExif = NULL;
+        binaryExif = nullptr;
         binary_size = 0;
         byteorder = Exiv2::littleEndian; // that's today's default....
     };

--- a/src/metadata/SipiIcc.cpp
+++ b/src/metadata/SipiIcc.cpp
@@ -36,11 +36,11 @@ static const char __file__[] = __FILE__;
 namespace Sipi {
 
     SipiIcc::SipiIcc(const unsigned char *icc_buf, int icc_len) {
-        if ((icc_profile = cmsOpenProfileFromMem(icc_buf, icc_len)) == NULL) {
+        if ((icc_profile = cmsOpenProfileFromMem(icc_buf, icc_len)) == nullptr) {
             std::cerr << "THROWING ERROR IN ICC" << std::endl;
             throw SipiError(__file__, __LINE__, "cmsOpenProfileFromMem failed");
         }
-        unsigned int len = cmsGetProfileInfoASCII(icc_profile, cmsInfoDescription, cmsNoLanguage, cmsNoCountry, NULL, 0);
+        unsigned int len = cmsGetProfileInfoASCII(icc_profile, cmsInfoDescription, cmsNoLanguage, cmsNoCountry, nullptr, 0);
         char *buf = new char[len];
         cmsGetProfileInfoASCII(icc_profile, cmsInfoDescription, cmsNoLanguage, cmsNoCountry, buf, len);
         if (strcmp(buf, "sRGB IEC61966-2.1") == 0) {
@@ -55,33 +55,35 @@ namespace Sipi {
     }
 
     SipiIcc::SipiIcc(const SipiIcc &icc_p) {
-        if (icc_p.icc_profile != NULL) {
-            char *buf = NULL;
+        if (icc_p.icc_profile != nullptr) {
+            char *buf = nullptr;
             cmsUInt32Number len = 0;
-            cmsSaveProfileToMem(icc_p.icc_profile, NULL, &len);
+            cmsSaveProfileToMem(icc_p.icc_profile, nullptr, &len);
             buf = new char[len];
             cmsSaveProfileToMem(icc_p.icc_profile, buf, &len);
-            if ((icc_profile = cmsOpenProfileFromMem(buf, len)) == NULL) {
-	    delete [] buf; // fixing memory leak?
+            icc_profile = cmsOpenProfileFromMem(buf, len);
+            delete [] buf;
+
+            if (icc_profile == nullptr) {
                 throw SipiError(__file__, __LINE__, "cmsOpenProfileFromMem failed");
             }
-	    delete [] buf; // fixing memory leak?
+
             profile_type = icc_p.profile_type;
         }
         else {
-            icc_profile = NULL;
+            icc_profile = nullptr;
             profile_type = icc_undefined;
         }
     }
 
     SipiIcc::SipiIcc(cmsHPROFILE &icc_profile_p) {
-        if (icc_profile_p != NULL) {
-            char *buf = NULL;
+        if (icc_profile_p != nullptr) {
+            char *buf = nullptr;
             cmsUInt32Number len = 0;
-            cmsSaveProfileToMem(icc_profile_p, NULL, &len);
+            cmsSaveProfileToMem(icc_profile_p, nullptr, &len);
             buf = new char[len];
             cmsSaveProfileToMem(icc_profile_p, buf, &len);
-            if ((icc_profile = cmsOpenProfileFromMem(buf, len)) == NULL) {
+            if ((icc_profile = cmsOpenProfileFromMem(buf, len)) == nullptr) {
                 delete [] buf;
                 throw SipiError(__file__, __LINE__, "cmsOpenProfileFromMem failed");
             }
@@ -93,7 +95,7 @@ namespace Sipi {
     SipiIcc::SipiIcc(PredefinedProfiles predef) {
         switch (predef) {
             case icc_undefined: {
-                icc_profile = NULL;
+                icc_profile = nullptr;
                 profile_type = icc_undefined;
             }
             case icc_unknown: {
@@ -145,7 +147,7 @@ namespace Sipi {
 
         cmsContext context = cmsCreateContext(0, 0);
         cmsToneCurve *tonecurve[3];
-        if (tfunc == NULL) {
+        if (tfunc == nullptr) {
             tonecurve[0] = cmsBuildGamma(context, 2.2);
             tonecurve[1] = cmsBuildGamma(context, 2.2);
             tonecurve[2] = cmsBuildGamma(context, 2.2);
@@ -162,20 +164,20 @@ namespace Sipi {
     }
 
     SipiIcc::~SipiIcc() {
-        if (icc_profile != NULL) {
+        if (icc_profile != nullptr) {
             cmsCloseProfile(icc_profile);
         }
     }
 
     SipiIcc& SipiIcc::operator=(const SipiIcc &rhs) {
         if (this != &rhs) {
-            if (rhs.icc_profile != NULL) {
-                char *buf = NULL;
+            if (rhs.icc_profile != nullptr) {
+                char *buf = nullptr;
                 unsigned int len = 0;
-                cmsSaveProfileToMem(rhs.icc_profile, NULL, &len);
+                cmsSaveProfileToMem(rhs.icc_profile, nullptr, &len);
                 buf = new char[len];
                 cmsSaveProfileToMem(rhs.icc_profile, buf, &len);
-                if ((icc_profile = cmsOpenProfileFromMem(buf, len)) == NULL) {
+                if ((icc_profile = cmsOpenProfileFromMem(buf, len)) == nullptr) {
                     throw SipiError(__file__, __LINE__, "cmsOpenProfileFromMem failed");
                 }
             }
@@ -185,10 +187,10 @@ namespace Sipi {
     }
 
     unsigned char *SipiIcc::iccBytes(unsigned int &len) {
-        unsigned char *buf = NULL;
+        unsigned char *buf = nullptr;
         len = 0;
-        if (icc_profile != NULL) {
-            if (!cmsSaveProfileToMem(icc_profile, NULL, &len)) throw SipiError(__file__, __LINE__, "cmsSaveProfileToMem failed");
+        if (icc_profile != nullptr) {
+            if (!cmsSaveProfileToMem(icc_profile, nullptr, &len)) throw SipiError(__file__, __LINE__, "cmsSaveProfileToMem failed");
             buf = new unsigned char[len];
             if (!cmsSaveProfileToMem(icc_profile, buf, &len)) throw SipiError(__file__, __LINE__, "cmsSaveProfileToMem failed");
         }
@@ -312,25 +314,25 @@ namespace Sipi {
     }
 
     std::ostream &operator<< (std::ostream &outstr, SipiIcc &rhs) {
-        unsigned int len = cmsGetProfileInfoASCII(rhs.icc_profile, cmsInfoDescription, cmsNoLanguage, cmsNoCountry, NULL, 0);
+        unsigned int len = cmsGetProfileInfoASCII(rhs.icc_profile, cmsInfoDescription, cmsNoLanguage, cmsNoCountry, nullptr, 0);
         char *buf = new char[len];
         cmsGetProfileInfoASCII(rhs.icc_profile, cmsInfoDescription, cmsNoLanguage, cmsNoCountry, buf, len);
         outstr << "ICC-Description : " << buf << std::endl;
         delete [] buf;
 
-        len = cmsGetProfileInfoASCII(rhs.icc_profile, cmsInfoManufacturer, cmsNoLanguage, cmsNoCountry, NULL, 0);
+        len = cmsGetProfileInfoASCII(rhs.icc_profile, cmsInfoManufacturer, cmsNoLanguage, cmsNoCountry, nullptr, 0);
         buf = new char[len];
         cmsGetProfileInfoASCII(rhs.icc_profile, cmsInfoManufacturer, cmsNoLanguage, cmsNoCountry, buf, len);
         outstr << "ICC-Manufacturer: " << buf << std::endl;
         delete [] buf;
 
-        len = cmsGetProfileInfoASCII(rhs.icc_profile, cmsInfoModel, cmsNoLanguage, cmsNoCountry, NULL, 0);
+        len = cmsGetProfileInfoASCII(rhs.icc_profile, cmsInfoModel, cmsNoLanguage, cmsNoCountry, nullptr, 0);
         buf = new char[len];
         cmsGetProfileInfoASCII(rhs.icc_profile, cmsInfoModel, cmsNoLanguage, cmsNoCountry, buf, len);
         outstr << "ICC-Model       : " << buf << std::endl;
         delete [] buf;
 
-        len = cmsGetProfileInfoASCII(rhs.icc_profile, cmsInfoCopyright, cmsNoLanguage, cmsNoCountry, NULL, 0);
+        len = cmsGetProfileInfoASCII(rhs.icc_profile, cmsInfoCopyright, cmsNoLanguage, cmsNoCountry, nullptr, 0);
         buf = new char[len];
         cmsGetProfileInfoASCII(rhs.icc_profile, cmsInfoCopyright, cmsNoLanguage, cmsNoCountry, buf, len);
         outstr << "ICC-Copyright   : " << buf << std::endl;

--- a/src/sipi.cpp
+++ b/src/sipi.cpp
@@ -332,6 +332,7 @@ int main (int argc, char *argv[]) {
 
         ~_SipiInit() {
             curl_global_cleanup();
+            Exiv2::XmpParser::terminate();
         }
     } sipiInit;
 

--- a/src/sipi.cpp
+++ b/src/sipi.cpp
@@ -76,7 +76,7 @@
  *     sipi [options] <infile> <outfile>
  *
  */
-Sipi::SipiHttpServer *serverptr = nullptr;
+
 Sipi::SipiConf sipiConf;
 enum FileType {image, video, audio, text, binary};
 
@@ -508,7 +508,6 @@ int main (int argc, char *argv[]) {
                 server.addRoute(shttps::Connection::POST, docroute, shttps::FileHandler, &filehandler_info);
             }
 
-            serverptr = &server;
             server.run();
 
         }
@@ -543,7 +542,7 @@ int main (int argc, char *argv[]) {
             std::cerr << options[IMGROOT].desc->help << std::endl;
             return EXIT_FAILURE;
         }
-        serverptr = &server;
+
         server.run();
 
     }
@@ -610,7 +609,8 @@ int main (int argc, char *argv[]) {
         //
         // getting information about a region of interest
         //
-        Sipi::SipiRegion *region = nullptr;
+        std::shared_ptr<Sipi::SipiRegion> region;
+
         if (options[REGION]) {
             std::vector<int> regV;
             try {
@@ -634,13 +634,14 @@ int main (int argc, char *argv[]) {
                 std::cerr << options[REGION].desc->help << std::endl;
                 return EXIT_FAILURE;
             }
-            region = new Sipi::SipiRegion(regV.at(0),
-                                          regV.at(1),
-                                          regV.at(2),
-                                          regV.at(3));
+            region = std::make_shared<Sipi::SipiRegion>(regV.at(0),
+                                                        regV.at(1),
+                                                        regV.at(2),
+                                                        regV.at(3));
         }
 
-        Sipi::SipiSize *size = nullptr;
+        std::shared_ptr<Sipi::SipiSize> size;
+
         //
         // get the reduce parameter
         // "reduce" is a special feature of the JPEG2000 format. It is possible (given the JPEG2000 format
@@ -657,7 +658,7 @@ int main (int argc, char *argv[]) {
             return EXIT_FAILURE;
         }
         if (reduce > 0) {
-            size = new Sipi::SipiSize(reduce);
+            size = std::make_shared<Sipi::SipiSize>(reduce);
         }
         else if (options[SIZE]) {
             try {
@@ -671,10 +672,10 @@ int main (int argc, char *argv[]) {
                     }
                 }
                 if (sizV.size() == 2) {
-                    size = new Sipi::SipiSize(sizV.at(0), sizV.at(1));
+                    size = std::make_shared<Sipi::SipiSize>(sizV.at(0), sizV.at(1));
                 }
                 else {
-                    size = new Sipi::SipiSize(sizV.at(0), sizV.at(0), true);
+                    size = std::make_shared<Sipi::SipiSize>(sizV.at(0), sizV.at(0), true);
                 }
             }
             catch(std::exception& e) {
@@ -685,7 +686,7 @@ int main (int argc, char *argv[]) {
         }
         else if (options[SCALE]) {
             try {
-                size = new Sipi::SipiSize(std::stoi(options[SCALE].arg));
+                size = std::make_shared<Sipi::SipiSize>(std::stoi(options[SCALE].arg));
             }
             catch(std::exception& e) {
                 std::cout << "##" << __LINE__ << std::endl;
@@ -705,8 +706,6 @@ int main (int argc, char *argv[]) {
                 img.removeChan(img.getNc() - 1);
             }
         }
-        delete region;
-        delete size;
 
         //
         // if we want to remove all metadata from the file...

--- a/src/sipi.cpp
+++ b/src/sipi.cpp
@@ -76,7 +76,7 @@
  *     sipi [options] <infile> <outfile>
  *
  */
-Sipi::SipiHttpServer *serverptr = NULL;
+Sipi::SipiHttpServer *serverptr = nullptr;
 Sipi::SipiConf sipiConf;
 enum FileType {image, video, audio, text, binary};
 
@@ -610,7 +610,7 @@ int main (int argc, char *argv[]) {
         //
         // getting information about a region of interest
         //
-        Sipi::SipiRegion *region = NULL;
+        Sipi::SipiRegion *region = nullptr;
         if (options[REGION]) {
             std::vector<int> regV;
             try {
@@ -640,7 +640,7 @@ int main (int argc, char *argv[]) {
                                           regV.at(3));
         }
 
-        Sipi::SipiSize *size = NULL;
+        Sipi::SipiSize *size = nullptr;
         //
         // get the reduce parameter
         // "reduce" is a special feature of the JPEG2000 format. It is possible (given the JPEG2000 format


### PR DESCRIPTION
This fixes some memory leaks identified by valgrind, and introduces some smart pointers to help prevent them in the future.

* Before shutting down, free memory allocated on startup.
* Fix some leaks that could occur when exceptions are thrown.
* Use `std::shared_ptr` for:
  * some member variables of `SipiImage`
  * `SipiSize`
  * `SipiRegion`
  * `SipiCache`
* Use `std::unique_ptr` for `SockStream` in `Server`.
* Fix a mutex deadlock that could occur on shutdown in `Server`.
* When copying a `SipiImage`, copy its members.
* Get rid of the global `Server` pointer, which was always passed from `main()` anyway.
* Replace `mktemp()` with the safer `mkstemp()`.
* Replace `NULL` with the safer keyword `nullptr` from C++11.
* Use `auto` to eliminate some compiler warnings about type conversions.
* Replace some C-style casts with `static_cast`.
* Rename some variables that were shadowing other variables.
* Rename some variables that were called `tmp`.

Using the smart pointers doesn't seem to have any effect on performance.

I put some questions in TODOs in `Connection.cpp`, lines 478-80.