### PR TITLE
Fix crash on bad config file

### DIFF
--- a/shttps/LuaServer.h
+++ b/shttps/LuaServer.h
@@ -149,7 +149,7 @@ namespace shttps {
 
 
         std::string configString(const std::string table, const std::string variable, const std::string defval);
-        int configBoolean(const std::string table, const std::string variable, const bool defval);
+        bool configBoolean(const std::string table, const std::string variable, const bool defval);
         int configInteger(const std::string table, const std::string variable, const int defval);
         float configFloat(const std::string table, const std::string variable, const float defval);
         const std::vector<LuaRoute> configRoute(const std::string routetable);


### PR DESCRIPTION
If `routes` in the config file is not a Lua table, this makes Sipi say:

```
$ local/bin/sipi -c config/sipi.init-knora.lua

Sipi Version 1.0 Beta (build 2017-02-02 14:33)
Sipi Source Git-Version: 8d195e7
Error at [/Users/benjamingeer/git/Sipi/shttps/LuaServer.cpp: 2538]: Value 'routes' in config file must be a table
```

Fixes #85.