### PR TITLE
Improve error checking in SipiSize and SipiRotation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -318,7 +318,7 @@ add_executable(
         shttps/Connection.cpp shttps/Connection.h
         shttps/LuaServer.cpp shttps/LuaServer.h
         shttps/LuaSqlite.cpp shttps/LuaSqlite.h
-        shttps/GetMimetype.cpp shttps/GetMimetype.h
+        shttps/Parsing.cpp shttps/Parsing.h
         shttps/Server.cpp shttps/Server.h
         shttps/jwt.c shttps/jwt.h
         shttps/makeunique.h)

--- a/include/iiifparser/SipiRotation.h
+++ b/include/iiifparser/SipiRotation.h
@@ -36,7 +36,7 @@ namespace Sipi {
     public:
         inline SipiRotation() {
             mirror = false;
-            rotation = static_cast<float>(0.);
+            rotation = 0.F;
         }
 
         SipiRotation(std::string str);

--- a/include/iiifparser/SipiRotation.h
+++ b/include/iiifparser/SipiRotation.h
@@ -32,16 +32,16 @@ namespace Sipi {
     class SipiRotation {
     private:
         bool mirror;
-        double rotation;
+        float rotation;
     public:
         inline SipiRotation() {
             mirror = false;
-            rotation = 0.;
+            rotation = static_cast<float>(0.);
         }
 
         SipiRotation(std::string str);
 
-        inline bool get_rotation(double &rot) {
+        inline bool get_rotation(float &rot) {
             rot = rotation;
             return mirror;
         };

--- a/include/iiifparser/SipiRotation.h
+++ b/include/iiifparser/SipiRotation.h
@@ -32,7 +32,7 @@ namespace Sipi {
     class SipiRotation {
     private:
         bool mirror;
-        float rotation;
+        double rotation;
     public:
         inline SipiRotation() {
             mirror = false;
@@ -41,7 +41,7 @@ namespace Sipi {
 
         SipiRotation(std::string str);
 
-        inline bool get_rotation(float &rot) {
+        inline bool get_rotation(double &rot) {
             rot = rotation;
             return mirror;
         };

--- a/include/iiifparser/SipiSize.h
+++ b/include/iiifparser/SipiSize.h
@@ -57,7 +57,7 @@ namespace Sipi {
     private:
         static size_t limitdim; //!< maximal dimension of an image
         SizeType size_type; //!< Holds the type of size/scaling parameters given
-        double percent;      //!< if the scaling is given in percent, this holds the value
+        float percent;      //!< if the scaling is given in percent, this holds the value
         int reduce;         //!< if the scaling is given by a reduce value
         bool redonly;       //!< we *only* have a reduce in the resulting size
         size_t nx, ny;         //!< the parameters given
@@ -82,7 +82,7 @@ namespace Sipi {
          *
          * \param[in] percent_p Percentage parameter
          */
-        inline SipiSize(double percent_p) : percent(percent_p) { size_type = SizeType::PERCENTS; }
+        inline SipiSize(float percent_p) : percent(percent_p) { size_type = SizeType::PERCENTS; }
 
         /*!
          * Construcor taking size/scale part of IIIF url as parameter

--- a/include/iiifparser/SipiSize.h
+++ b/include/iiifparser/SipiSize.h
@@ -29,24 +29,24 @@
 
 namespace Sipi {
 
-   /*!
-    * \class SipiSize
-    * This class handles both the Size (or scale) parameter of a IIIF-request, but also deals
-    * with the reduce parameter which can be used in reading J2K images
-    * In order to support the reduce, the syntax "red:int" can be used, e.g.:
-    * http://{url}/{prefix}/{identifier}/{region}/red:3/{rotation}/default.jpg
-    * The class can be constructed in several ways and just stores the parameters.
-    * The width/height that should be applied to the scaling is calculated by calling
-    * the get_size() method. It is to note that get_size() may also return a reduce
-    * factor. This may be used in case of the JPEG2000 where it es much more efficient
-    * to have the reduce factor while reading the image (since using a reduce > 0 means
-    * that only a fraction of the input file has to be read)
-    *
-    */
+    /*!
+     * \class SipiSize
+     * This class handles both the Size (or scale) parameter of a IIIF-request, but also deals
+     * with the reduce parameter which can be used in reading J2K images
+     * In order to support the reduce, the syntax "red:int" can be used, e.g.:
+     * http://{url}/{prefix}/{identifier}/{region}/red:3/{rotation}/default.jpg
+     * The class can be constructed in several ways and just stores the parameters.
+     * The width/height that should be applied to the scaling is calculated by calling
+     * the get_size() method. It is to note that get_size() may also return a reduce
+     * factor. This may be used in case of the JPEG2000 where it es much more efficient
+     * to have the reduce factor while reading the image (since using a reduce > 0 means
+     * that only a fraction of the input file has to be read)
+     *
+     */
     class SipiSize {
     public:
         typedef enum {
-            FULL,      //!< The full size of the image is served, IIIF: "full"
+            FULL,      //!< The full size of the image is served, IIIF: "full" or "max"
             PIXELS_XY, //!< Both X and Y is given, the image may be distorted, IIIF: "xxx,yyy"
             PIXELS_X,  //!< Only the X dimension is given, the Y dimension is calculated (no distortion), IIIF: "xxx,"
             PIXELS_Y,  //!< Only the Y dimension is given, the X dimension is calculated (no distortion), IIIF: ",yyy"
@@ -55,9 +55,9 @@ namespace Sipi {
             REDUCE     //!< A reduce factor can be given, 0=no scaling, 1=0.5, 2=0.25, 3=0.125,...(Note: this is an extension to the IIIF standard) IIIF: "red:ii"
         } SizeType;
     private:
-        static int limitdim; //!< maximal dimension of an image
+        static size_t limitdim; //!< maximal dimension of an image
         SizeType size_type; //!< Holds the type of size/scaling parameters given
-        float percent;      //!< if the scaling is given in percent, this holds the value
+        double percent;      //!< if the scaling is given in percent, this holds the value
         int reduce;         //!< if the scaling is given by a reduce value
         bool redonly;       //!< we *only* have a reduce in the resulting size
         size_t nx, ny;         //!< the parameters given
@@ -65,108 +65,97 @@ namespace Sipi {
         bool canonical_ok;
 
     public:
-       /*!
-        * Default constructor (full size)
-        */
+        /*!
+         * Default constructor (full size)
+         */
         inline SipiSize() { size_type = SizeType::FULL; }
 
-       /*!
-        * Constructor with reduce parameter (reduce=0: full image, reduce=1: 1/2, reduce=2: 1/4,…)
-        *
-        * \param[in] reduce_p Reduce parameter
-        */
+        /*!
+         * Constructor with reduce parameter (reduce=0: full image, reduce=1: 1/2, reduce=2: 1/4,…)
+         *
+         * \param[in] reduce_p Reduce parameter
+         */
         inline SipiSize(int reduce_p) : reduce(reduce_p) { size_type = SizeType::REDUCE; }
 
-       /*!
-        * Constructor with percentage parameter
-        *
-        * \param[in] percent_p Percentage parameter
-        */
-        inline SipiSize(float percent_p) : percent(percent_p) { size_type = SizeType::PERCENTS; }
+        /*!
+         * Constructor with percentage parameter
+         *
+         * \param[in] percent_p Percentage parameter
+         */
+        inline SipiSize(double percent_p) : percent(percent_p) { size_type = SizeType::PERCENTS; }
 
-       /*!
-        * Constructor with dimensions. IF one of the dimensions is equal zero, this dimension
-        * will be calculated from the other without distorting the image. If both dimensions are gt 0,
-        * the image may be distorted
-        *
-        * \param[in] nx_p Width of scaled image
-        * \param[in] ny_p Height of scaled image
-        * \param[in] maxdim If true, the scaled image (without distortion) will fit into the given region
-        */
-        SipiSize(size_t nx_p, size_t ny_p, bool maxdim = false);
-
-       /*!
-        * Construcor taking size/scale part of IIIF url as parameter
-        *
-        * \param[in] str String with the IIIF url part containing the size/scaling information
-        */
+        /*!
+         * Construcor taking size/scale part of IIIF url as parameter
+         *
+         * \param[in] str String with the IIIF url part containing the size/scaling information
+         */
         SipiSize(std::string str);
 
         /*!
-         * Comparison operater ">"
+         * Comparison operator ">"
          */
-        bool operator >(const SipiSize &s);
+        bool operator>(const SipiSize &s);
 
         /*!
-         * Comparison operater ">="
+         * Comparison operator ">="
          */
-        bool operator >=(const SipiSize &s);
+        bool operator>=(const SipiSize &s);
 
         /*!
-         * Comparison operater "<"
+         * Comparison operator "<"
          */
-        bool operator <(const SipiSize &s);
+        bool operator<(const SipiSize &s);
 
         /*!
-         * Comparison operater "<="
+         * Comparison operator "<="
          */
-        bool operator <=(const SipiSize &s);
+        bool operator<=(const SipiSize &s);
 
-       /*!
-        * Get the coordinate type that has bee used for construction of the region
-        *
-        * \returns CoordType
-        */
+        /*!
+         * Get the coordinate type that has bee used for construction of the region
+         *
+         * \returns CoordType
+         */
         inline SizeType getType() { return size_type; };
 
-       /*!
-        * Get the size to which the image should be scaled
-        *
-        * \param[out] nx_p Width of scaled image
-        * \param[out] nx_p Height of scaled image
-        * \param[out] percent_p Percentage of scaling (if percentage was indicated)
-        *
-        * \returns enum SizeType which indicates how the size was specified
-        */
-       /*
-        inline SizeType get_size(int &nx_p, int &ny_p, float &percent_p) {
-            nx_p = nx; ny_p = ny; percent_p = percent;
-            return size_type;
-        };
-        */
-       /*!
-        * Get the size to which the image should be scaled
-        *
-        * \param[in] nx Width of original images
-        * \param[in] ny original height of image
-        * \param[out] w_p Width of scaled image
-        * \param[out] h_p Height of scaled image
-        * \param[out] reduce_p Reduce parameter (especially for J2K images with resolution pyramid)
-        * \param[out] rdonly_p True, if scaling can be made with the reduce parameter only
-        *
-        * \returns enum SizeType which indicates how the size was specified
-        */
+        /*!
+         * Get the size to which the image should be scaled
+         *
+         * \param[out] nx_p Width of scaled image
+         * \param[out] nx_p Height of scaled image
+         * \param[out] percent_p Percentage of scaling (if percentage was indicated)
+         *
+         * \returns enum SizeType which indicates how the size was specified
+         */
+        /*
+         inline SizeType get_size(int &nx_p, int &ny_p, float &percent_p) {
+             nx_p = nx; ny_p = ny; percent_p = percent;
+             return size_type;
+         };
+         */
+        /*!
+         * Get the size to which the image should be scaled
+         *
+         * \param[in] nx Width of original images
+         * \param[in] ny original height of image
+         * \param[out] w_p Width of scaled image
+         * \param[out] h_p Height of scaled image
+         * \param[out] reduce_p Reduce parameter (especially for J2K images with resolution pyramid)
+         * \param[out] rdonly_p True, if scaling can be made with the reduce parameter only
+         *
+         * \returns enum SizeType which indicates how the size was specified
+         */
         SipiSize::SizeType get_size(size_t nx, size_t ny, size_t &w_p, size_t &h_p, int &reduce_p, bool &redonly_p);
 
-       /*!
-        * Returns the canoncial IIIF string for the given size/scaling
-        *
-        * \param[in] Pointer to character buffer
-        * \param[in] Length of the character buffer
-        */
+        /*!
+         * Returns the canoncial IIIF string for the given size/scaling
+         *
+         * \param[in] Pointer to character buffer
+         * \param[in] Length of the character buffer
+         */
         void canonical(char *buf, int buflen);
 
-        friend std::ostream &operator<< (std::ostream &lhs, const SipiSize &rhs);
+        friend std::ostream &operator<<(std::ostream &lhs, const SipiSize &rhs);
     };
 
 }

--- a/shttps/CMakeLists.txt
+++ b/shttps/CMakeLists.txt
@@ -143,7 +143,7 @@ add_library(
         ChunkReader.cpp ChunkReader.h
         Connection.cpp Connection.h
         LuaServer.cpp LuaServer.h
-        GetMimetype.cpp GetMimetype.h
+        Parsing.cpp Parsing.h
         Server.cpp Server.h
         jwt.c jwt.h
 )

--- a/shttps/LuaServer.cpp
+++ b/shttps/LuaServer.cpp
@@ -47,7 +47,7 @@
 #include "ChunkReader.h"
 
 #include "sole.hpp"
-#include "GetMimetype.h"
+#include "Parsing.h"
 
 
 #ifdef SHTTPS_ENABLE_SSL
@@ -2085,7 +2085,7 @@ namespace shttps {
         lua_pop(L, top);
 
         try {
-            std::pair<std::string, std::string> mimetype = GetMimetype::parseMimetype(mimestr); // returns a pair of strings: mimetype and charset
+            std::pair<std::string, std::string> mimetype = Parsing::parseMimetype(mimestr); // returns a pair of strings: mimetype and charset
             return return_mimetype_to_lua(L, mimetype);
         }
         catch (Error &err) {
@@ -2123,7 +2123,7 @@ namespace shttps {
         lua_pop(L, top);
 
         try {
-            std::pair<std::string, std::string> mimetype = GetMimetype::getFileMimetype(path); // returns a pair of strings: mimetype and charset
+            std::pair<std::string, std::string> mimetype = Parsing::getFileMimetype(path); // returns a pair of strings: mimetype and charset
             return return_mimetype_to_lua(L, mimetype);
         }
         catch (Error &err) {

--- a/shttps/Parsing.cpp
+++ b/shttps/Parsing.cpp
@@ -24,7 +24,7 @@
 #include <regex>
 #include <sstream>
 
-#include "GetMimetype.h"
+#include "Parsing.h"
 #include "Error.h"
 
 #include "magic.h"
@@ -33,13 +33,14 @@ static const char __file__[] = __FILE__;
 
 namespace shttps {
 
-    namespace GetMimetype {
+    namespace Parsing {
 
-        std::pair<std::string, std::string> parseMimetype(const std::string& mimestr) {
+        std::pair<std::string, std::string> parseMimetype(const std::string &mimestr) {
             try {
                 // A regex for parsing the value of an HTTP Content-Type header. In C++11, initialization of this
                 // static local variable happens once and is thread-safe.
-                static std::regex mime_regex("^([^;]+)(;\\s*charset=\"?([^\"]+)\"?)?$", std::regex_constants::ECMAScript | std::regex_constants::icase);
+                static std::regex mime_regex("^([^;]+)(;\\s*charset=\"?([^\"]+)\"?)?$",
+                                             std::regex_constants::ECMAScript | std::regex_constants::icase);
 
                 std::smatch mime_match;
                 std::string mimetype;
@@ -55,6 +56,7 @@ namespace shttps {
                     }
                 } else {
                     std::ostringstream error_msg;
+                    error_msg << "Could not parse MIME type: " << mimestr;
                     throw Error(__file__, __LINE__, error_msg.str());
                 }
 
@@ -63,14 +65,14 @@ namespace shttps {
                 std::transform(charset.begin(), charset.end(), charset.begin(), ::tolower);
 
                 return std::make_pair(mimetype, charset);
-            } catch (std::regex_error& e) {
+            } catch (std::regex_error &e) {
                 std::ostringstream error_msg;
                 error_msg << "Regex error: " << e.what();
                 throw Error(__file__, __LINE__, error_msg.str());
             }
         }
 
-        std::pair<std::string, std::string> getFileMimetype(const std::string& fpath) {
+        std::pair<std::string, std::string> getFileMimetype(const std::string &fpath) {
             magic_t handle;
             if ((handle = magic_open(MAGIC_MIME | MAGIC_PRESERVE_ATIME)) == nullptr) {
                 throw Error(__file__, __LINE__, magic_error(handle));
@@ -82,6 +84,56 @@ namespace shttps {
 
             std::string mimestr(magic_file(handle, fpath.c_str()));
             return parseMimetype(mimestr);
+        }
+
+        size_t parse_int(std::string &str) {
+            try {
+                // A regex for parsing an integer containing only digits. In C++11, initialization of this
+                // static local variable happens once and is thread-safe.
+                static std::regex int_regex("^[0-9]+$", std::regex_constants::ECMAScript);
+
+                std::smatch int_match;
+
+                if (std::regex_match(str, int_match, int_regex)) {
+                    std::stringstream sstream(int_match[0]);
+                    size_t result;
+                    sstream >> result;
+                    return result;
+                } else {
+                    std::ostringstream error_msg;
+                    error_msg << "Could not parse integer: " << str;
+                    throw Error(__file__, __LINE__, error_msg.str());
+                }
+            } catch (std::regex_error &e) {
+                std::ostringstream error_msg;
+                error_msg << "Regex error: " << e.what();
+                throw Error(__file__, __LINE__, error_msg.str());
+            }
+        }
+
+        double parse_double(std::string &str) {
+            try {
+                // A regex for parsing an integer containing only digits and an optional decimal point. In C++11,
+                // initialization of this static local variable happens once and is thread-safe.
+                static std::regex double_regex("^[0-9]+(\\.[0-9]+)?$", std::regex_constants::ECMAScript);
+
+                std::smatch double_match;
+
+                if (std::regex_match(str, double_match, double_regex)) {
+                    std::stringstream sstream(double_match[0]);
+                    double result;
+                    sstream >> result;
+                    return result;
+                } else {
+                    std::ostringstream error_msg;
+                    error_msg << "Could not parse floating-point number: " << str;
+                    throw Error(__file__, __LINE__, error_msg.str());
+                }
+            } catch (std::regex_error &e) {
+                std::ostringstream error_msg;
+                error_msg << "Regex error: " << e.what();
+                throw Error(__file__, __LINE__, error_msg.str());
+            }
         }
     }
 }

--- a/shttps/Parsing.cpp
+++ b/shttps/Parsing.cpp
@@ -111,17 +111,17 @@ namespace shttps {
             }
         }
 
-        double parse_double(std::string &str) {
+        float parse_float(std::string &str) {
             try {
-                // A regex for parsing an integer containing only digits and an optional decimal point. In C++11,
+                // A regex for parsing a floating-point number containing only digits and an optional decimal point. In C++11,
                 // initialization of this static local variable happens once and is thread-safe.
-                static std::regex double_regex("^[0-9]+(\\.[0-9]+)?$", std::regex_constants::ECMAScript);
+                static std::regex float_regex("^[0-9]+(\\.[0-9]+)?$", std::regex_constants::ECMAScript);
 
-                std::smatch double_match;
+                std::smatch float_match;
 
-                if (std::regex_match(str, double_match, double_regex)) {
-                    std::stringstream sstream(double_match[0]);
-                    double result;
+                if (std::regex_match(str, float_match, float_regex)) {
+                    std::stringstream sstream(float_match[0]);
+                    float result;
                     sstream >> result;
                     return result;
                 } else {

--- a/shttps/Parsing.h
+++ b/shttps/Parsing.h
@@ -63,7 +63,7 @@ namespace shttps {
          * @param str the string to be parsed.
          * @return the corresponding floating-point number.
          */
-        double parse_double(std::string &str);
+        float parse_float(std::string &str);
     }
 }
 

--- a/shttps/Parsing.h
+++ b/shttps/Parsing.h
@@ -20,41 +20,51 @@
  * You should have received a copy of the GNU Affero General Public
  * License along with Sipi.  If not, see <http://www.gnu.org/licenses/>.
  */
-#ifndef __shttps_getmimetype_h
-#define __shttps_getmimetype_h
+#ifndef __shttps_parsing_h
+#define __shttps_parsing_h
 
 #include <string>
 #include <regex>
 
 namespace shttps {
 
-   /*!
-    * \brief Wrapper for libmagic mimetype guesser
-    *
-    * Implements a function which guesses the mimetype of a file
-    * using the magic number (that is the signature of the first few bytes)
-    * of a file.
-    */
-    namespace GetMimetype {
+    /*!
+     * \brief Parsing utilities.
+     */
+    namespace Parsing {
         /*!
          * Parses a string containing a MIME type and optional character set, such as the Content-Type header defined by
          * <https://tools.ietf.org/html/rfc7231#section-3.1.1>.
          * @param mimestr a string containing the MIME type.
          * @return the MIME type and optional character set.
          */
-        std::pair<std::string, std::string> parseMimetype(const std::string& mimestr);
+        std::pair<std::string, std::string> parseMimetype(const std::string &mimestr);
 
 
-       /*!
-        * Determine the mimetype of a file using the magic number
-        *
-        * \param[in] fpath Path to file to check for the mimetype
-        * \returns pair<string,string> containing the mimetype as first part
-        *          and the charset as second part. Access as val.first and val.second!
-        */
-        std::pair<std::string,std::string> getFileMimetype(const std::string& fpath);
-    };
+        /*!
+         * Determine the mimetype of a file using the magic number
+         *
+         * \param[in] fpath Path to file to check for the mimetype
+         * \returns pair<string,string> containing the mimetype as first part
+         *          and the charset as second part. Access as val.first and val.second!
+         */
+        std::pair<std::string, std::string> getFileMimetype(const std::string &fpath);
 
+        /*!
+         * Parses an integer.
+         * @param str the string to be parsed.
+         * @return the corresponding integer.
+         */
+        size_t parse_int(std::string &str);
+
+        /*!
+         * Parses a floating-point number containing only digits and an optional decimal point.
+         *
+         * @param str the string to be parsed.
+         * @return the corresponding floating-point number.
+         */
+        double parse_double(std::string &str);
+    }
 }
 
-#endif //__shttps_getmimetype_h
+#endif //__shttps_parsing_h

--- a/shttps/Server.cpp
+++ b/shttps/Server.cpp
@@ -54,7 +54,7 @@
 #include "SockStream.h"
 #include "Server.h"
 #include "LuaServer.h"
-#include "GetMimetype.h"
+#include "Parsing.h"
 #include "makeunique.h"
 
 static const char __file__[] = __FILE__;
@@ -314,7 +314,7 @@ namespace shttps {
             return;
         }
 
-        std::pair<std::string, std::string> mime = GetMimetype::getFileMimetype(infile);
+        std::pair<std::string, std::string> mime = Parsing::getFileMimetype(infile);
 
         size_t extpos = uri.find_last_of('.');
         std::string extension;

--- a/src/SipiHttpServer.cpp
+++ b/src/SipiHttpServer.cpp
@@ -475,16 +475,16 @@ namespace Sipi {
 
         size->canonical(canonical_size, canonical_len);
 
-        float angle;
+        double angle;
         bool mirror = rotation.get_rotation(angle);
 
         char canonical_rotation[canonical_len + 1];
         if (mirror || (angle != 0.0)) {
-            if ((angle - floorf(angle)) < 1.0e-6) { // it's an integer
+            if ((angle - floor(angle)) < 1.0e-6) { // it's an integer
                 if (mirror) {
-                    (void) snprintf(canonical_rotation, canonical_len, "!%ld", lroundf(angle));
+                    (void) snprintf(canonical_rotation, canonical_len, "!%ld", lround(angle));
                 } else {
-                    (void) snprintf(canonical_rotation, canonical_len, "%ld", lroundf(angle));
+                    (void) snprintf(canonical_rotation, canonical_len, "%ld", lround(angle));
                 }
             } else {
                 if (mirror) {
@@ -834,7 +834,7 @@ namespace Sipi {
         }
 
 
-        float angle;
+        double angle;
         bool mirror = rotation.get_rotation(angle);
 
         //
@@ -848,15 +848,19 @@ namespace Sipi {
                 send_error(conn_obj, Connection::BAD_REQUEST, "PDF must have size qualifier of \"full\"");
                 return;
             }
+
             if (region->getType() != SipiRegion::FULL) {
                 send_error(conn_obj, Connection::BAD_REQUEST, "PDF must have region qualifier of \"full\"");
                 return;
             }
-            float rot;
+
+            double rot;
+
             if (rotation.get_rotation(rot) || (rot != 0.0)) {
                 send_error(conn_obj, Connection::BAD_REQUEST, "PDF must have rotation qualifier of \"0\"");
                 return;
             }
+
             if ((quality_format.quality() != SipiQualityFormat::DEFAULT) ||
                 (quality_format.format() != SipiQualityFormat::PDF)) {
                 send_error(conn_obj, Connection::BAD_REQUEST, "PDF must have quality qualifier of \"default.pdf\"");

--- a/src/SipiHttpServer.cpp
+++ b/src/SipiHttpServer.cpp
@@ -480,7 +480,7 @@ namespace Sipi {
 
         char canonical_rotation[canonical_len + 1];
         if (mirror || (angle != 0.0)) {
-            if ((angle - floor(angle)) < 1.0e-6) { // it's an integer
+            if ((angle - floorf(angle)) < 1.0e-6) { // it's an integer
                 if (mirror) {
                     (void) snprintf(canonical_rotation, canonical_len, "!%ld", lround(angle));
                 } else {

--- a/src/SipiHttpServer.cpp
+++ b/src/SipiHttpServer.cpp
@@ -475,7 +475,7 @@ namespace Sipi {
 
         size->canonical(canonical_size, canonical_len);
 
-        double angle;
+        float angle;
         bool mirror = rotation.get_rotation(angle);
 
         char canonical_rotation[canonical_len + 1];
@@ -834,7 +834,7 @@ namespace Sipi {
         }
 
 
-        double angle;
+        float angle;
         bool mirror = rotation.get_rotation(angle);
 
         //
@@ -854,7 +854,7 @@ namespace Sipi {
                 return;
             }
 
-            double rot;
+            float rot;
 
             if (rotation.get_rotation(rot) || (rot != 0.0)) {
                 send_error(conn_obj, Connection::BAD_REQUEST, "PDF must have rotation qualifier of \"0\"");
@@ -924,8 +924,8 @@ namespace Sipi {
             (angle == 0.0) &&
             (!mirror) && watermark.empty() &&
             (quality_format.format() == in_format) &&
-            (quality_format.quality() == SipiQualityFormat::DEFAULT)
-                ) {
+            (quality_format.quality() == SipiQualityFormat::DEFAULT)) {
+
             syslog(LOG_DEBUG, "Sending unmodified file....");
             conn_obj.status(Connection::OK);
             conn_obj.header("Cache-Control", "must-revalidate, post-check=0, pre-check=0");
@@ -935,38 +935,42 @@ namespace Sipi {
                     conn_obj.header("Content-Type", "image/tiff"); // set the header (mimetype)
                     break;
                 }
+
                 case SipiQualityFormat::JPG: {
                     conn_obj.header("Content-Type", "image/jpeg"); // set the header (mimetype)
                     break;
                 }
+
                 case SipiQualityFormat::PNG: {
                     conn_obj.header("Content-Type", "image/png"); // set the header (mimetype)
                     break;
                 }
+
                 case SipiQualityFormat::JP2: {
                     conn_obj.header("Content-Type", "image/jp2"); // set the header (mimetype)
                     break;
                 }
+
                 case SipiQualityFormat::PDF: {
                     conn_obj.header("Content-Type", "application/pdf"); // set the header (mimetype)
                     break;
                 }
-                default: {
-                }
+
+                default: {}
             }
+
             try {
                 syslog(LOG_INFO, "Sending file %s", infile.c_str());
                 conn_obj.sendFile(infile);
-            }
-            catch (int err) {
+            } catch (int err) {
                 // -1 was thrown
                 syslog(LOG_WARNING, "Browser unexpectedly closed connection");
                 return;
-            }
-            catch (Sipi::SipiError &err) {
+            } catch (Sipi::SipiError &err) {
                 send_error(conn_obj, Connection::INTERNAL_SERVER_ERROR, err);
                 return;
             }
+
             return;
         }
 
@@ -988,43 +992,47 @@ namespace Sipi {
                         conn_obj.header("Content-Type", "image/tiff"); // set the header (mimetype)
                         break;
                     }
+
                     case SipiQualityFormat::JPG: {
                         conn_obj.header("Content-Type", "image/jpeg"); // set the header (mimetype)
                         break;
                     }
+
                     case SipiQualityFormat::PNG: {
                         conn_obj.header("Content-Type", "image/png"); // set the header (mimetype)
                         break;
                     }
+
                     case SipiQualityFormat::JP2: {
                         conn_obj.header("Content-Type", "image/jp2"); // set the header (mimetype)
                         break;
                     }
-                    default: {
-                    }
+
+                    default: {}
                 }
+
                 try {
                     syslog(LOG_DEBUG, "Sending cachefile %s", cachefile.c_str());
                     conn_obj.sendFile(cachefile);
-                }
-                catch (int err) {
+                } catch (int err) {
                     // -1 was thrown
                     syslog(LOG_WARNING, "Browser unexpectedly closed connection");
                     return;
-                }
-                catch (Sipi::SipiError &err) {
+                } catch (Sipi::SipiError &err) {
                     send_error(conn_obj, Connection::INTERNAL_SERVER_ERROR, err);
                     return;
                 }
+
                 return;
             }
         }
+
         syslog(LOG_WARNING, "Nothing found in cache, reading and transforming file...");
         Sipi::SipiImage img;
+
         try {
             img.read(infile, region, size, quality_format.format() == SipiQualityFormat::JPG);
-        }
-        catch (const SipiImageError &err) {
+        } catch (const SipiImageError &err) {
             send_error(conn_obj, Connection::INTERNAL_SERVER_ERROR, err.to_string());
             return;
         }

--- a/src/SipiHttpServer.cpp
+++ b/src/SipiHttpServer.cpp
@@ -64,12 +64,12 @@ namespace Sipi {
     static const std::string pre_flight_func_name = "pre_flight";
 
     typedef enum {
-        iiif_prefix = 0,			//!< http://{url}/*{prefix}*/{id}/{region}/{size}/{rotation}/{quality}.{format}
-        iiif_identifier = 1,		//!< http://{url}/{prefix}/*{id}*/{region}/{size}/{rotation}/{quality}.{format}
-        iiif_region = 2,			//!< http://{url}/{prefix}/{id}/{region}/{size}/{rotation}/{quality}.{format}
-        iiif_size = 3,				//!< http://{url}/{prefix}/{id}/{region}/*{size}*/{rotation}/{quality}.{format}
-        iiif_rotation = 4,			//!< http://{url}/{prefix}/{id}/{region}/{size}/*{rotation}*/{quality}.{format}
-        iiif_qualityformat = 5,		//!< http://{url}/{prefix}/{id}/{region}/{size}/{rotation}/*{quality}.{format}*
+        iiif_prefix = 0,            //!< http://{url}/*{prefix}*/{id}/{region}/{size}/{rotation}/{quality}.{format}
+        iiif_identifier = 1,        //!< http://{url}/{prefix}/*{id}*/{region}/{size}/{rotation}/{quality}.{format}
+        iiif_region = 2,            //!< http://{url}/{prefix}/{id}/{region}/{size}/{rotation}/{quality}.{format}
+        iiif_size = 3,                //!< http://{url}/{prefix}/{id}/{region}/*{size}*/{rotation}/{quality}.{format}
+        iiif_rotation = 4,            //!< http://{url}/{prefix}/{id}/{region}/{size}/*{rotation}*/{quality}.{format}
+        iiif_qualityformat = 5,        //!< http://{url}/{prefix}/{id}/{region}/{size}/{rotation}/*{quality}.{format}*
     } IiifParams;
 
     /*!
@@ -186,7 +186,8 @@ namespace Sipi {
      * \param luaserver the Lua server that will be used to call the function.
      * \param params the HTTP request parameters.
      */
-    static std::pair<std::string, std::string> call_pre_flight(Connection &conn_obj, shttps::LuaServer &luaserver, std::vector<std::string> &params) {
+    static std::pair<std::string, std::string>
+    call_pre_flight(Connection &conn_obj, shttps::LuaServer &luaserver, std::vector<std::string> &params) {
         // The permission and optional file path that the pre_fight function returns.
         std::string permission;
         std::string infile;
@@ -250,7 +251,8 @@ namespace Sipi {
                 }
             } else {
                 std::ostringstream err_msg;
-                err_msg << "Lua function " << pre_flight_func_name << " returned permission 'allow', but it did not return a file path";
+                err_msg << "Lua function " << pre_flight_func_name
+                        << " returned permission 'allow', but it did not return a file path";
                 throw SipiError(__file__, __LINE__, err_msg.str());
             }
         }
@@ -260,7 +262,8 @@ namespace Sipi {
     }
 
 
-    static void iiif_send_info(Connection &conn_obj, SipiHttpServer *serv, shttps::LuaServer &luaserver, std::vector<std::string> &params, const std::string &imgroot, bool prefix_as_path) {
+    static void iiif_send_info(Connection &conn_obj, SipiHttpServer *serv, shttps::LuaServer &luaserver,
+                               std::vector<std::string> &params, const std::string &imgroot, bool prefix_as_path) {
         conn_obj.setBuffer(); // we want buffered output, since we send JSON text...
         const std::string contenttype = conn_obj.header("accept");
 
@@ -303,7 +306,7 @@ namespace Sipi {
 
             try {
                 pre_flight_return_values = call_pre_flight(conn_obj, luaserver, params);
-            } catch (SipiError& err) {
+            } catch (SipiError &err) {
                 send_error(conn_obj, Connection::INTERNAL_SERVER_ERROR, err);
                 return;
             }
@@ -315,13 +318,11 @@ namespace Sipi {
                 send_error(conn_obj, Connection::UNAUTHORIZED, "Unauthorized access");
                 return;
             }
-        }
-        else {
+        } else {
             if (prefix_as_path) {
                 infile = serv->imgroot() + "/" + urldecode(params[iiif_prefix]) + "/" +
                          urldecode(params[iiif_identifier]);
-            }
-            else {
+            } else {
                 infile = serv->imgroot() + "/" + urldecode(params[iiif_identifier]);
             }
         }
@@ -335,17 +336,18 @@ namespace Sipi {
         }
         if (!contenttype.empty() && (contenttype == "application/ld+json")) {
             conn_obj.header("Content-Type", "application/ld+json");
-        }
-        else {
+        } else {
             conn_obj.header("Content-Type", "application/json");
-            conn_obj.header("Link", "<http://iiif.io/api/image/2/context.json>; rel=\"http://www.w3.org/ns/json-ld#context\"; type=\"application/ld+json\"");
+            conn_obj.header("Link",
+                            "<http://iiif.io/api/image/2/context.json>; rel=\"http://www.w3.org/ns/json-ld#context\"; type=\"application/ld+json\"");
         }
         json_t *root = json_object();
 
         json_object_set_new(root, "@context", json_string("http://iiif.io/api/image/2/context.json"));
 
         std::string host = conn_obj.header("host");
-        std::string id = std::string("http://") + host + "/" + params[iiif_prefix] + "/" + params[iiif_identifier]; //// ?????????????????????????????????????
+        std::string id = std::string("http://") + host + "/" + params[iiif_prefix] + "/" +
+                         params[iiif_identifier]; //// ?????????????????????????????????????
         json_object_set_new(root, "@id", json_string(id.c_str()));
 
         json_object_set_new(root, "protocol", json_string("http://iiif.io/api/image"));
@@ -360,7 +362,7 @@ namespace Sipi {
             try {
                 tmpimg.getDim(infile, width, height);
             }
-            catch(SipiImageError &err) {
+            catch (SipiImageError &err) {
                 send_error(conn_obj, Connection::INTERNAL_SERVER_ERROR, err.to_string());
                 return;
             }
@@ -388,39 +390,39 @@ namespace Sipi {
         json_array_append_new(profile_arr, json_string("http://iiif.io/api/image/2/level2.json"));
         json_t *profile = json_object();
 
-        const char * formats_str[] = {"tif", "jpg", "png", "jp2"};
+        const char *formats_str[] = {"tif", "jpg", "png", "jp2"};
         json_t *formats = json_array();
-        for (unsigned int i = 0; i < sizeof(formats_str)/sizeof(char*); i++) {
+        for (unsigned int i = 0; i < sizeof(formats_str) / sizeof(char *); i++) {
             json_array_append_new(formats, json_string(formats_str[i]));
         }
         json_object_set_new(profile, "formats", formats);
 
         const char *qualities_str[] = {"color", "gray"};
         json_t *qualities = json_array();
-        for (unsigned int i = 0; i < sizeof(qualities_str)/sizeof(char*); i++) {
+        for (unsigned int i = 0; i < sizeof(qualities_str) / sizeof(char *); i++) {
             json_array_append_new(qualities, json_string(qualities_str[i]));
         }
         json_object_set_new(profile, "qualities", qualities);
 
-        const char * supports_str[] = {
-            "color",
-            "cors",
-            "mirroring",
-            "profileLinkHeader",
-            "regionByPct",
-            "regionByPx",
-            "rotationArbitrary",
-            "rotationBy90s",
-            "sizeAboveFull",
-            "sizeByWhListed",
-            "sizeByForcedWh",
-            "sizeByH",
-            "sizeByPct",
-            "sizeByW",
-            "sizeByWh"
+        const char *supports_str[] = {
+                "color",
+                "cors",
+                "mirroring",
+                "profileLinkHeader",
+                "regionByPct",
+                "regionByPx",
+                "rotationArbitrary",
+                "rotationBy90s",
+                "sizeAboveFull",
+                "sizeByWhListed",
+                "sizeByForcedWh",
+                "sizeByH",
+                "sizeByPct",
+                "sizeByW",
+                "sizeByWh"
         };
         json_t *supports = json_array();
-        for (unsigned int i = 0; i < sizeof(supports_str)/sizeof(char*); i++) {
+        for (unsigned int i = 0; i < sizeof(supports_str) / sizeof(char *); i++) {
             json_array_append_new(supports, json_string(supports_str[i]));
         }
         json_object_set_new(profile, "supports", supports);
@@ -433,7 +435,7 @@ namespace Sipi {
 
         conn_obj.sendAndFlush(json_str, strlen(json_str));
 
-        free (json_str);
+        free(json_str);
 
         //TODO and all the other CJSON obj?
         json_decref(root);
@@ -451,8 +453,7 @@ namespace Sipi {
                                                                           std::shared_ptr<SipiRegion> region,
                                                                           std::shared_ptr<SipiSize> size,
                                                                           SipiRotation &rotation,
-                                                                          SipiQualityFormat &quality_format)
-    {
+                                                                          SipiQualityFormat &quality_format) {
         static const int canonical_len = 127;
 
         char canonical_region[canonical_len + 1];
@@ -482,22 +483,18 @@ namespace Sipi {
             if ((angle - floorf(angle)) < 1.0e-6) { // it's an integer
                 if (mirror) {
                     (void) snprintf(canonical_rotation, canonical_len, "!%ld", lroundf(angle));
-                }
-                else {
+                } else {
                     (void) snprintf(canonical_rotation, canonical_len, "%ld", lroundf(angle));
                 }
-            }
-            else {
+            } else {
                 if (mirror) {
                     (void) snprintf(canonical_rotation, canonical_len, "!%1.1f", angle);
-                }
-                else {
+                } else {
                     (void) snprintf(canonical_rotation, canonical_len, "%1.1f", angle);
                 }
             }
             syslog(LOG_DEBUG, "Rotation (canonical): %s", canonical_rotation);
-        }
-        else {
+        } else {
             (void) snprintf(canonical_rotation, canonical_len, "0");
         }
 
@@ -506,22 +503,43 @@ namespace Sipi {
         char ext[5];
         switch (quality_format.format()) {
             case SipiQualityFormat::JPG: {
-                ext[0] = 'j'; ext[1] = 'p'; ext[2] = 'g'; ext[3] = '\0'; break; // jpg
+                ext[0] = 'j';
+                ext[1] = 'p';
+                ext[2] = 'g';
+                ext[3] = '\0';
+                break; // jpg
             }
             case SipiQualityFormat::JP2: {
-                ext[0] = 'j'; ext[1] = 'p'; ext[2] = '2'; ext[3] = '\0'; break; // jp2
+                ext[0] = 'j';
+                ext[1] = 'p';
+                ext[2] = '2';
+                ext[3] = '\0';
+                break; // jp2
             }
             case SipiQualityFormat::TIF: {
-                ext[0] = 't'; ext[1] = 'i'; ext[2] = 'f'; ext[3] = '\0'; break; // tif
+                ext[0] = 't';
+                ext[1] = 'i';
+                ext[2] = 'f';
+                ext[3] = '\0';
+                break; // tif
             }
             case SipiQualityFormat::PNG: {
-                ext[0] = 'p'; ext[1] = 'n'; ext[2] = 'g'; ext[3] = '\0'; break; // png
+                ext[0] = 'p';
+                ext[1] = 'n';
+                ext[2] = 'g';
+                ext[3] = '\0';
+                break; // png
             }
             case SipiQualityFormat::PDF: {
-                ext[0] = 'p'; ext[1] = 'd'; ext[2] = 'f'; ext[3] = '\0'; break; // pdf
+                ext[0] = 'p';
+                ext[1] = 'd';
+                ext[2] = 'f';
+                ext[3] = '\0';
+                break; // pdf
             }
             default: {
-                throw SipiError(__file__, __LINE__, "Unsupported file format requested! Supported are .jpg, .jp2, .tif, .png, .pdf");
+                throw SipiError(__file__, __LINE__,
+                                "Unsupported file format requested! Supported are .jpg, .jp2, .tif, .png, .pdf");
             }
         }
 
@@ -544,23 +562,24 @@ namespace Sipi {
                     format = "/default.";
                 }
             }
-        }
-        else {
+        } else {
             format = "/default.";
         }
 
-        (void) snprintf(canonical_header, canonical_header_len, "<http://%s/%s/%s/%s/%s/%s/default.%s>; rel=\"canonical\"",
-                        host.c_str(), prefix.c_str(), identifier.c_str(), canonical_region, canonical_size, canonical_rotation, ext);
+        (void) snprintf(canonical_header, canonical_header_len,
+                        "<http://%s/%s/%s/%s/%s/%s/default.%s>; rel=\"canonical\"",
+                        host.c_str(), prefix.c_str(), identifier.c_str(), canonical_region, canonical_size,
+                        canonical_rotation, ext);
         std::string canonical = host + "/" + prefix + "/" + identifier + "/" + std::string(canonical_region) + "/" +
-                           std::string(canonical_size) + "/" + std::string(canonical_rotation) + format + std::string(ext);
+                                std::string(canonical_size) + "/" + std::string(canonical_rotation) + format +
+                                std::string(ext);
 
         return make_pair(std::string(canonical_header), canonical);
     }
     //=========================================================================
 
 
-    static void process_get_request(Connection &conn_obj, shttps::LuaServer &luaserver, void *user_data, void *dummy)
-    {
+    static void process_get_request(Connection &conn_obj, shttps::LuaServer &luaserver, void *user_data, void *dummy) {
         SipiHttpServer *serv = (SipiHttpServer *) user_data;
 
         bool prefix_as_path = serv->prefix_as_path();
@@ -597,9 +616,9 @@ namespace Sipi {
         if (params.size() == 3) {
             std::string infile;
             if (prefix_as_path) {
-                infile = serv->imgroot() + "/" + urldecode(params[iiif_prefix]) + "/" + urldecode(params[iiif_identifier]);
-            }
-            else {
+                infile = serv->imgroot() + "/" + urldecode(params[iiif_prefix]) + "/" +
+                         urldecode(params[iiif_identifier]);
+            } else {
                 infile = serv->imgroot() + "/" + urldecode(params[iiif_identifier]);
             }
 
@@ -607,15 +626,16 @@ namespace Sipi {
                 conn_obj.setBuffer();
                 conn_obj.status(Connection::SEE_OTHER);
                 const std::string host = conn_obj.header("host");
-                std::string redirect = std::string("http://") + host + "/" + params[iiif_prefix] + "/" + params[iiif_identifier] + "/info.json";
+                std::string redirect =
+                        std::string("http://") + host + "/" + params[iiif_prefix] + "/" + params[iiif_identifier] +
+                        "/info.json";
                 conn_obj.header("Location", redirect);
                 conn_obj.header("Content-Type", "text/plain");
                 conn_obj << "Redirect to " << redirect;
                 syslog(LOG_INFO, "GET: redirect to %s", redirect.c_str());
                 conn_obj.flush();
                 return;
-            }
-            else {
+            } else {
                 syslog(LOG_WARNING, "GET: %s not accessible", infile.c_str());
                 send_error(conn_obj, Connection::NOT_FOUND);
                 conn_obj.flush();
@@ -652,7 +672,7 @@ namespace Sipi {
             return;
         }
 
-         //
+        //
         // getting region parameters
         //
         auto region = std::make_shared<SipiRegion>();
@@ -661,8 +681,7 @@ namespace Sipi {
             std::stringstream ss;
             ss << *region;
             syslog(LOG_DEBUG, "%s", ss.str().c_str());
-        }
-        catch (Sipi::SipiError &err) {
+        } catch (Sipi::SipiError &err) {
             send_error(conn_obj, Connection::BAD_REQUEST, err);
             return;
         }
@@ -676,8 +695,7 @@ namespace Sipi {
             std::stringstream ss;
             ss << *size;
             syslog(LOG_DEBUG, "%s", ss.str().c_str());
-        }
-        catch (Sipi::SipiError &err) {
+        } catch (Sipi::SipiError &err) {
             send_error(conn_obj, Connection::BAD_REQUEST, err);
             return;
         }
@@ -691,8 +709,7 @@ namespace Sipi {
             std::stringstream ss;
             ss << rotation;
             syslog(LOG_DEBUG, "%s", ss.str().c_str());
-        }
-        catch (Sipi::SipiError &err) {
+        } catch (Sipi::SipiError &err) {
             send_error(conn_obj, Connection::BAD_REQUEST, err);
             return;
         }
@@ -750,7 +767,7 @@ namespace Sipi {
 
             try {
                 pre_flight_return_values = call_pre_flight(conn_obj, luaserver, params);
-            } catch (SipiError& err) {
+            } catch (SipiError &err) {
                 send_error(conn_obj, Connection::INTERNAL_SERVER_ERROR, err);
                 return;
             }
@@ -772,27 +789,22 @@ namespace Sipi {
                     std::string restriction_param = qualifier.substr(colon_pos + 1);
                     if (restriction_type == "watermark") {
                         watermark = restriction_param;
-                    }
-                    else if (restriction_type == "size") {
+                    } else if (restriction_type == "size") {
                         restriction_size = std::make_shared<SipiSize>(restriction_param);
-                    }
-                    else {
+                    } else {
                         send_error(conn_obj, Connection::UNAUTHORIZED, "Unauthorized access");
                         return;
                     }
-                }
-                else {
+                } else {
                     send_error(conn_obj, Connection::UNAUTHORIZED, "Unauthorized access");
                     return;
                 }
             }
-        }
-        else {
+        } else {
             if (prefix_as_path) {
                 infile = serv->imgroot() + "/" + urldecode(params[iiif_prefix]) + "/" +
                          urldecode(params[iiif_identifier]);
-            }
-            else {
+            } else {
                 infile = serv->imgroot() + "/" + urldecode(params[iiif_identifier]);
             }
         }
@@ -805,18 +817,14 @@ namespace Sipi {
         }
         if ((extension == "tif") || (extension == "TIF") || (extension == "tiff") || (extension == "TIFF")) {
             in_format = SipiQualityFormat::TIF;
-        }
-        else if ((extension == "jpg") || (extension == "JPG")) {
+        } else if ((extension == "jpg") || (extension == "JPG")) {
             in_format = SipiQualityFormat::JPG;
-        }
-        else if ((extension == "png") || (extension == "PNG")) {
+        } else if ((extension == "png") || (extension == "PNG")) {
             in_format = SipiQualityFormat::PNG;
-        }
-        else if ((extension == "j2k") || (extension == "J2K") || (extension == "jp2") || (extension == "JP2") ||
-                 (extension == "jpx") || (extension == "JPX")) {
+        } else if ((extension == "j2k") || (extension == "J2K") || (extension == "jp2") || (extension == "JP2") ||
+                   (extension == "jpx") || (extension == "JPX")) {
             in_format = SipiQualityFormat::JP2;
-        }
-        else if ((extension == "pdf") || (extension == "PDF")) {
+        } else if ((extension == "pdf") || (extension == "PDF")) {
             in_format = SipiQualityFormat::PDF;
         }
         if (access(infile.c_str(), R_OK) != 0) { // test, if file exists
@@ -849,12 +857,12 @@ namespace Sipi {
                 send_error(conn_obj, Connection::BAD_REQUEST, "PDF must have rotation qualifier of \"0\"");
                 return;
             }
-            if ((quality_format.quality() != SipiQualityFormat::DEFAULT) || (quality_format.format() != SipiQualityFormat::PDF)) {
+            if ((quality_format.quality() != SipiQualityFormat::DEFAULT) ||
+                (quality_format.format() != SipiQualityFormat::PDF)) {
                 send_error(conn_obj, Connection::BAD_REQUEST, "PDF must have quality qualifier of \"default.pdf\"");
                 return;
             }
-        }
-        else {
+        } else {
             //
             // get image dimensions, needed for get_canonical...
             //
@@ -863,7 +871,7 @@ namespace Sipi {
                 try {
                     tmpimg.getDim(infile, img_w, img_h);
                 }
-                catch(SipiImageError &err) {
+                catch (SipiImageError &err) {
                     send_error(conn_obj, Connection::INTERNAL_SERVER_ERROR, err.to_string());
                     return;
                 }
@@ -896,7 +904,7 @@ namespace Sipi {
                                               rotation,
                                               quality_format);
         }
-        catch(Sipi::SipiError &err) {
+        catch (Sipi::SipiError &err) {
             send_error(conn_obj, Connection::BAD_REQUEST, err);
             return;
         }
@@ -913,7 +921,7 @@ namespace Sipi {
             (!mirror) && watermark.empty() &&
             (quality_format.format() == in_format) &&
             (quality_format.quality() == SipiQualityFormat::DEFAULT)
-        ) {
+                ) {
             syslog(LOG_DEBUG, "Sending unmodified file....");
             conn_obj.status(Connection::OK);
             conn_obj.header("Cache-Control", "must-revalidate, post-check=0, pre-check=0");
@@ -946,12 +954,12 @@ namespace Sipi {
                 syslog(LOG_INFO, "Sending file %s", infile.c_str());
                 conn_obj.sendFile(infile);
             }
-            catch(int err) {
+            catch (int err) {
                 // -1 was thrown
                 syslog(LOG_WARNING, "Browser unexpectedly closed connection");
                 return;
             }
-            catch(Sipi::SipiError &err) {
+            catch (Sipi::SipiError &err) {
                 send_error(conn_obj, Connection::INTERNAL_SERVER_ERROR, err);
                 return;
             }
@@ -995,12 +1003,12 @@ namespace Sipi {
                     syslog(LOG_DEBUG, "Sending cachefile %s", cachefile.c_str());
                     conn_obj.sendFile(cachefile);
                 }
-                catch(int err) {
+                catch (int err) {
                     // -1 was thrown
                     syslog(LOG_WARNING, "Browser unexpectedly closed connection");
                     return;
                 }
-                catch(Sipi::SipiError &err) {
+                catch (Sipi::SipiError &err) {
                     send_error(conn_obj, Connection::INTERNAL_SERVER_ERROR, err);
                     return;
                 }
@@ -1012,7 +1020,7 @@ namespace Sipi {
         try {
             img.read(infile, region, size, quality_format.format() == SipiQualityFormat::JPG);
         }
-        catch(const SipiImageError &err) {
+        catch (const SipiImageError &err) {
             send_error(conn_obj, Connection::INTERNAL_SERVER_ERROR, err.to_string());
             return;
         }
@@ -1024,7 +1032,7 @@ namespace Sipi {
             try {
                 img.rotate(angle, mirror);
             }
-            catch(Sipi::SipiError &err) {
+            catch (Sipi::SipiError &err) {
                 send_error(conn_obj, Connection::INTERNAL_SERVER_ERROR, err);
                 return;
             }
@@ -1059,7 +1067,7 @@ namespace Sipi {
             try {
                 img.add_watermark(watermark);
             }
-            catch(Sipi::SipiError &err) {
+            catch (Sipi::SipiError &err) {
                 send_error(conn_obj, Connection::INTERNAL_SERVER_ERROR, err);
                 return;
             }
@@ -1197,12 +1205,12 @@ namespace Sipi {
                     conn_obj.status(Connection::BAD_REQUEST);
                     conn_obj.header("Content-Type", "text/plain");
                     conn_obj << "Not Implemented!\n";
-                    conn_obj <<"Unsupported file format requested! Supported are .jpg, .jp2, .tif, .png\n";
+                    conn_obj << "Unsupported file format requested! Supported are .jpg, .jp2, .tif, .png\n";
                     conn_obj.flush();
                 }
             }
         }
-        catch(Sipi::SipiError &err) {
+        catch (Sipi::SipiError &err) {
             send_error(conn_obj, Connection::INTERNAL_SERVER_ERROR, err);
             return;
         }
@@ -1221,8 +1229,7 @@ namespace Sipi {
     }
     //=========================================================================
 
-    static void test_handler(Connection &conn_obj, shttps::LuaServer &luaserver, void *user_data, void *dummy)
-    {
+    static void test_handler(Connection &conn_obj, shttps::LuaServer &luaserver, void *user_data, void *dummy) {
         lua_State *L = luaL_newstate();
         luaL_openlibs(L);
 
@@ -1234,8 +1241,7 @@ namespace Sipi {
     }
     //=========================================================================
 
-    static void exit_handler(Connection &conn_obj, shttps::LuaServer &luaserver, void *user_data, void *dummy)
-    {
+    static void exit_handler(Connection &conn_obj, shttps::LuaServer &luaserver, void *user_data, void *dummy) {
         std::cerr << "Exit handler called" << std::endl;
         conn_obj.status(Connection::OK);
         conn_obj.header("Content-Type", "text/plain");
@@ -1244,16 +1250,16 @@ namespace Sipi {
     }
     //=========================================================================
 
-    SipiHttpServer::SipiHttpServer(int port_p, unsigned nthreads_p, const std::string userid_str, const std::string &logfile_p, const std::string &loglevel_p)
-        : Server::Server(port_p, nthreads_p, userid_str, logfile_p, loglevel_p)
-    {
+    SipiHttpServer::SipiHttpServer(int port_p, unsigned nthreads_p, const std::string userid_str,
+                                   const std::string &logfile_p, const std::string &loglevel_p)
+            : Server::Server(port_p, nthreads_p, userid_str, logfile_p, loglevel_p) {
         _salsah_prefix = "imgrep";
         _cache = nullptr;
     }
     //=========================================================================
 
-    void SipiHttpServer::cache(const std::string &cachedir_p, long long max_cachesize_p, unsigned max_nfiles_p, float cache_hysteresis_p)
-    {
+    void SipiHttpServer::cache(const std::string &cachedir_p, long long max_cachesize_p, unsigned max_nfiles_p,
+                               float cache_hysteresis_p) {
         try {
             _cache = std::make_shared<SipiCache>(cachedir_p, max_cachesize_p, max_nfiles_p, cache_hysteresis_p);
         }

--- a/src/SipiImage.cpp
+++ b/src/SipiImage.cpp
@@ -34,7 +34,7 @@
 //#include "formats/SipiIOOpenJ2k.h"
 #include "formats/SipiIOJpeg.h"
 #include "formats/SipiIOPng.h"
-#include "shttps/GetMimetype.h"
+#include "shttps/Parsing.h"
 
 static const char __file__[] = __FILE__;
 
@@ -208,7 +208,7 @@ namespace Sipi {
     {
         try
         {
-            std::string actual_mimetype = shttps::GetMimetype::getFileMimetype(path).first;
+            std::string actual_mimetype = shttps::Parsing::getFileMimetype(path).first;
 
             if (actual_mimetype != given_mimetype) {
                 //std::cerr << actual_mimetype << " does not equal " << given_mimetype << std::endl;
@@ -282,7 +282,7 @@ namespace Sipi {
             internal_hash.add_data(pixels, nx * ny * nc * bps / 8);
             std::string checksum = internal_hash.hash();
             std::string origname = shttps::getFileName(filepath);
-            std::string mimetype = shttps::GetMimetype::getFileMimetype(filepath).first;
+            std::string mimetype = shttps::Parsing::getFileMimetype(filepath).first;
             SipiEssentials emdata(origname, mimetype, shttps::HashType::sha256, checksum);
             essential_metadata(emdata);
         }
@@ -305,7 +305,7 @@ namespace Sipi {
             shttps::Hash internal_hash(htype);
             internal_hash.add_data(pixels, nx * ny * nc * bps / 8);
             std::string checksum = internal_hash.hash();
-            std::string mimetype = shttps::GetMimetype::getFileMimetype(filepath).first;
+            std::string mimetype = shttps::Parsing::getFileMimetype(filepath).first;
             SipiEssentials emdata(origname, mimetype, shttps::HashType::sha256, checksum);
             essential_metadata(emdata);
         }

--- a/src/SipiLua.cpp
+++ b/src/SipiLua.cpp
@@ -35,6 +35,7 @@
 #include "SipiLua.h"
 #include "SipiHttpServer.h"
 #include "SipiCache.h"
+#include "shttps/makeunique.h"
 
 namespace Sipi {
 
@@ -299,7 +300,7 @@ namespace Sipi {
     static SImage *toSImage(lua_State *L, int index) {
         SImage *img = (SImage *) lua_touserdata(L, index);
         if (img == nullptr) {
-            lua_pushstring(L, "Type error! Not userdata object");
+            lua_pushstring(L, "Type error: Not userdata object");
             lua_error(L);
         }
         return img;
@@ -311,7 +312,7 @@ namespace Sipi {
         luaL_checktype(L, index, LUA_TUSERDATA);
         img = (SImage *) luaL_checkudata(L, index, SIMAGE);
         if (img == nullptr) {
-            lua_pushstring(L, "Type error! Expected an SipiImage!");
+            lua_pushstring(L, "Type error: Expected an SipiImage");
             lua_error(L);
         }
         return img;
@@ -326,7 +327,7 @@ namespace Sipi {
     }
     //=========================================================================
 
-    /*!
+    /*
      * Lua usage:
      *    img = SipiImage.new("filename")
      *    img = SipiImage.new("filename",{region=<iiif-region-string>, size=<iiif-size-string> , reduce=<integer>, original=origfilename}, hash="md5"|"sha1"|"sha256"|"sha384"|"sha512")
@@ -336,13 +337,13 @@ namespace Sipi {
         if (top < 1) {
             lua_pop(L, top);
             lua_pushboolean(L, false);
-            lua_pushstring(L, "'SipiImage.new()': No filename given!");
+            lua_pushstring(L, "SipiImage.new(): No filename given");
             return 2;
         }
         if (!lua_isstring(L, 1)) {
             lua_pop(L, top);
             lua_pushboolean(L, false);
-            lua_pushstring(L, "'SipiImage.new()': filename must be string!");
+            lua_pushstring(L, "SipiImage.new(): filename must be string");
             return 2;
         }
         const char *imgpath = lua_tostring(L, 1);
@@ -358,7 +359,7 @@ namespace Sipi {
             else {
                 lua_pop(L, top);
                 lua_pushboolean(L, false);
-                lua_pushstring(L, "'SipiImage.new()': Second parameter must be table!");
+                lua_pushstring(L, "SipiImage.new(): Second parameter must be table");
                 return 2;
             }
             lua_pushnil(L);
@@ -372,7 +373,7 @@ namespace Sipi {
                         else {
                             lua_pop(L, lua_gettop(L));
                             lua_pushboolean(L, false);
-                            lua_pushstring(L, "'SipiImage.new()': Error in region parameter!");
+                            lua_pushstring(L, "SipiImage.new(): Error in region parameter");
                             return 2;
                         }
                     }
@@ -383,7 +384,7 @@ namespace Sipi {
                         else {
                             lua_pop(L, lua_gettop(L));
                             lua_pushboolean(L, false);
-                            lua_pushstring(L, "'SipiImage.new()': Error in size parameter!");
+                            lua_pushstring(L, "SipiImage.new(): Error in size parameter");
                             return 2;
                         }
                     }
@@ -394,7 +395,7 @@ namespace Sipi {
                         else {
                             lua_pop(L, lua_gettop(L));
                             lua_pushboolean(L, false);
-                            lua_pushstring(L, "'SipiImage.new()': Error in reduce parameter!");
+                            lua_pushstring(L, "SipiImage.new(): Error in reduce parameter");
                             return 2;
                         }
                     }
@@ -406,7 +407,7 @@ namespace Sipi {
                         else {
                             lua_pop(L, lua_gettop(L));
                             lua_pushboolean(L, false);
-                            lua_pushstring(L, "'SipiImage.new()': Error in original parameter!");
+                            lua_pushstring(L, "SipiImage.new(): Error in original parameter");
                             return 2;
                         }
                     }
@@ -432,25 +433,25 @@ namespace Sipi {
                             else {
                                 lua_pop(L, lua_gettop(L));
                                 lua_pushboolean(L, false);
-                                lua_pushstring(L, "'SipiImage.new()': Error in hash type!");
+                                lua_pushstring(L, "SipiImage.new(): Error in hash type");
                                 return 2;
                             }
                         }
                         else {
                             lua_pop(L, lua_gettop(L));
                             lua_pushboolean(L, false);
-                            lua_pushstring(L, "'SipiImage.new()': Error in hash parameter!");
+                            lua_pushstring(L, "SipiImage.new(): Error in hash parameter");
                             return 2;
                         }
                     }
                     else {
                         lua_pop(L, lua_gettop(L));
                         lua_pushboolean(L, false);
-                        lua_pushstring(L, "'SipiImage.new()': Error in parameter table (unknown parameter)!");
+                        lua_pushstring(L, "SipiImage.new(): Error in parameter table (unknown parameter)");
                         return 2;
                     }
                 }
-                /* removes 'value'; keeps 'key' for next iteration */
+                /* removes value; keeps key for next iteration */
                 lua_pop(L, 1);
             }
         }
@@ -471,7 +472,7 @@ namespace Sipi {
             lua_pop(L, lua_gettop(L));
             lua_pushboolean(L, false);
             std::stringstream ss;
-            ss << "'SipiImage.new()': ";
+            ss << "SipiImage.new(): ";
             ss << err;
             lua_pushstring(L, ss.str().c_str());
             return 2;
@@ -487,7 +488,7 @@ namespace Sipi {
         if (top != 1) {
             lua_pop(L, top);
             lua_pushboolean(L, false);
-            lua_pushstring(L, "'SipiImage.dims()': Incorrect number of arguments!");
+            lua_pushstring(L, "SipiImage.dims(): Incorrect number of arguments");
             return 2;
         }
 
@@ -501,7 +502,7 @@ namespace Sipi {
                 lua_pop(L, top);
                 lua_pushboolean(L, false);
                 std::stringstream ss;
-                ss << "'SipiImage.dims()': " << err;
+                ss << "SipiImage.dims(): " << err;
                 lua_pushstring(L, ss.str().c_str());
                 return 2;
             }
@@ -511,7 +512,7 @@ namespace Sipi {
             if (img == nullptr) {
                 lua_pop(L, top);
                 lua_pushboolean(L, false);
-                lua_pushstring(L, "'SipiImage.dims()': not a valid image!");
+                lua_pushstring(L, "SipiImage.dims(): not a valid image");
                 return 2;
             }
             nx = img->image->getNx();
@@ -544,7 +545,7 @@ namespace Sipi {
         if (top != 3) {
             lua_pop(L, top); // clear stack
             lua_pushboolean(L, false);
-            lua_pushstring(L, "'SipiImage.mimetype_consistency()': Incorrect number of arguments!");
+            lua_pushstring(L, "SipiImage.mimetype_consistency(): Incorrect number of arguments");
             return 2;
         }
 
@@ -568,7 +569,7 @@ namespace Sipi {
         catch (SipiImageError &err) {
             lua_pushboolean(L, false);
             std::stringstream ss;
-            ss << "'SipiImage.mimetype_consistency()': " << err;
+            ss << "SipiImage.mimetype_consistency(): " << err;
             lua_pushstring(L, ss.str().c_str());
             return 2;
         }
@@ -591,7 +592,7 @@ namespace Sipi {
         if (!lua_isstring(L, 2)) {
             lua_pop(L, top);
             lua_pushboolean(L, false);
-            lua_pushstring(L, "'SipiImage.crop()': Incorrect number of arguments!");
+            lua_pushstring(L, "SipiImage.crop(): Incorrect number of arguments");
             return 2;
         }
         const char *regionstr = lua_tostring(L, 2);
@@ -604,7 +605,7 @@ namespace Sipi {
         catch (SipiError &err) {
             lua_pushboolean(L, false);
             std::stringstream ss;
-            ss << "'SipiImage.crop()': " << err;
+            ss << "SipiImage.crop(): " << err;
             lua_pushstring(L, ss.str().c_str());
             return 2;
         }
@@ -628,30 +629,29 @@ namespace Sipi {
         if (!lua_isstring(L, 2)) {
             lua_pop(L, top);
             lua_pushboolean(L, false);
-            lua_pushstring(L, "'SipiImage.scale()': Incorrect number of arguments!");
+            lua_pushstring(L, "SipiImage.scale(): Incorrect number of arguments");
             return 2;
         }
         const char *sizestr = lua_tostring(L, 2);
         lua_pop(L, top);
 
-        SipiSize *size;
         size_t nx, ny;
+
         try {
-            size = new SipiSize(sizestr);
+            SipiSize size(sizestr);
             int r;
             bool ro;
-            size->get_size(img->image->getNx(), img->image->getNy(), nx, ny, r, ro);
+            size.get_size(img->image->getNx(), img->image->getNy(), nx, ny, r, ro);
         }
         catch (SipiError &err) {
             lua_pushboolean(L, false);
             std::stringstream ss;
-            ss << "'SipiImage.scale()': " << err;
+            ss << "SipiImage.scale(): " << err;
             lua_pushstring(L, ss.str().c_str());
             return 2;
         }
 
         img->image->scale(nx, ny);
-        delete size;
 
         lua_pushboolean(L, true);
         lua_pushnil(L);
@@ -668,14 +668,14 @@ namespace Sipi {
         if (top != 2) {
             lua_pop(L, top);
             lua_pushboolean(L, false);
-            lua_pushstring(L, "'SipiImage.rotate()': Incorrect number of arguments!");
+            lua_pushstring(L, "SipiImage.rotate(): Incorrect number of arguments");
             return 2;
         }
         SImage *img = checkSImage(L, 1);
 
         if (!lua_isnumber(L, 2)) {
             lua_pushboolean(L, false);
-            lua_pushstring(L, "'SipiImage.rotate()': Incorrect  arguments!");
+            lua_pushstring(L, "SipiImage.rotate(): Incorrect  arguments");
             return 2;
         }
         float angle = lua_tonumber(L, 2);
@@ -701,7 +701,7 @@ namespace Sipi {
         if (!lua_isstring(L, 2)) {
             lua_pop(L, top);
             lua_pushboolean(L, false);
-            lua_pushstring(L, "'SipiImage.watermark()': Incorrect arguments!");
+            lua_pushstring(L, "SipiImage.watermark(): Incorrect arguments");
             return 2;
         }
         const char *watermark = lua_tostring(L, 2);
@@ -713,7 +713,7 @@ namespace Sipi {
         catch(SipiImageError &err) {
             lua_pushboolean(L, false);
             std::stringstream ss;
-            ss << "'SipiImage.watermark()': " << err;
+            ss << "SipiImage.watermark(): " << err;
             lua_pushstring(L, ss.str().c_str());
             return 2;
         }
@@ -737,7 +737,7 @@ namespace Sipi {
         if (!lua_isstring(L, 2)) {
             lua_pop(L, top);
             lua_pushboolean(L, false);
-            lua_pushstring(L, "'SipiImage.write()': Incorrect arguments!");
+            lua_pushstring(L, "SipiImage.write(): Incorrect arguments");
             return 2;
         }
         const char *imgpath = lua_tostring(L, 2);
@@ -777,7 +777,7 @@ namespace Sipi {
             ftype = "jpx";
         }
         else {
-            lua_pushstring(L, "'SipiImage.write()': unsupported file format!");
+            lua_pushstring(L, "SipiImage.write(): unsupported file format");
             return lua_error(L);
         }
 
@@ -826,7 +826,7 @@ namespace Sipi {
         if (!lua_isstring(L, 2)) {
             lua_pop(L, top);
             lua_pushboolean(L, false);
-            lua_pushstring(L, "'SipiImage.send()': Incorrect arguments!");
+            lua_pushstring(L, "SipiImage.send(): Incorrect arguments");
             return 2;
         }
         const char *ext = lua_tostring(L, 2);
@@ -848,7 +848,7 @@ namespace Sipi {
             ftype = "jpx";
         }
         else {
-            lua_pushstring(L, "'SipiImage.send()': unsupported file format!");
+            lua_pushstring(L, "SipiImage.send(): unsupported file format");
             return lua_error(L);
         }
 

--- a/src/SipiLua.cpp
+++ b/src/SipiLua.cpp
@@ -35,7 +35,6 @@
 #include "SipiLua.h"
 #include "SipiHttpServer.h"
 #include "SipiCache.h"
-#include "shttps/makeunique.h"
 
 namespace Sipi {
 

--- a/src/iiifparser/SipiRotation.cpp
+++ b/src/iiifparser/SipiRotation.cpp
@@ -20,6 +20,7 @@
  * You should have received a copy of the GNU Affero General Public
  * License along with Sipi.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 #include <assert.h>
 #include <stdlib.h>
 #include <string>
@@ -37,38 +38,31 @@
 
 #include "SipiError.h"
 #include "SipiRotation.h"
+#include "shttps/Parsing.h"
 
 static const char __file__[] = __FILE__;
 
 namespace Sipi {
 
     SipiRotation::SipiRotation(std::string str) {
-        int n;
-        if (str.empty()) {
-            mirror = false;
-            rotation = 0.;
-            return;
-        }
-        if (str[0] == '!') { // with mirroring!
-            mirror = true;
-            if (str.length() > 1) {
-                n = sscanf(str.c_str(), "!%f", &rotation);
-                if (n != 1) {
-                    throw SipiError(__file__, __LINE__, "IIIF Error reading Rotation parameter  \"" + str + "\" !");
-                }
-            }
-            else {
+        try {
+            if (str.empty()) {
+                mirror = false;
                 rotation = 0.;
+                return;
             }
-        }
-        else {
-            mirror = false;
-            n = sscanf(str.c_str(), "%f", &rotation);
-            if (n != 1) {
-                throw SipiError(__file__, __LINE__, "IIIF Error reading Rotation parameter  \"" + str + "\" !");
+
+            bool mirror = str[0] == '!';
+
+            if (mirror) {
+                str.erase(0, 1);
             }
+
+            rotation = shttps::Parsing::parse_double(str);
+        } catch (shttps::Error &error) {
+            throw SipiError(__file__, __LINE__, "Could not parse IIIF rotation parameter: " + str);
         }
-    };
+    }
     //-------------------------------------------------------------------------
 
 
@@ -80,6 +74,6 @@ namespace Sipi {
         outstr << "  Mirror " << rhs.mirror;
         outstr << " | rotation = " << std::to_string(rhs.rotation);
         return outstr;
-    };
+    }
     //-------------------------------------------------------------------------
 }

--- a/src/iiifparser/SipiRotation.cpp
+++ b/src/iiifparser/SipiRotation.cpp
@@ -58,7 +58,7 @@ namespace Sipi {
                 str.erase(0, 1);
             }
 
-            rotation = static_cast<float>(shttps::Parsing::parse_double(str));
+            rotation = shttps::Parsing::parse_float(str);
         } catch (shttps::Error &error) {
             throw SipiError(__file__, __LINE__, "Could not parse IIIF rotation parameter: " + str);
         }

--- a/src/iiifparser/SipiRotation.cpp
+++ b/src/iiifparser/SipiRotation.cpp
@@ -48,7 +48,7 @@ namespace Sipi {
         try {
             if (str.empty()) {
                 mirror = false;
-                rotation = 0.;
+                rotation = static_cast<float>(0.);
                 return;
             }
 
@@ -58,7 +58,7 @@ namespace Sipi {
                 str.erase(0, 1);
             }
 
-            rotation = shttps::Parsing::parse_double(str);
+            rotation = static_cast<float>(shttps::Parsing::parse_double(str));
         } catch (shttps::Error &error) {
             throw SipiError(__file__, __LINE__, "Could not parse IIIF rotation parameter: " + str);
         }

--- a/src/iiifparser/SipiRotation.cpp
+++ b/src/iiifparser/SipiRotation.cpp
@@ -48,7 +48,7 @@ namespace Sipi {
         try {
             if (str.empty()) {
                 mirror = false;
-                rotation = static_cast<float>(0.);
+                rotation = 0.F;
                 return;
             }
 

--- a/src/iiifparser/SipiSize.cpp
+++ b/src/iiifparser/SipiSize.cpp
@@ -51,7 +51,7 @@ namespace Sipi {
 
     SipiSize::SipiSize(std::string str) {
         nx = ny = 0;
-        percent = 0.;
+        percent = static_cast<float>(0.);
         canonical_ok = false;
 
         try {
@@ -60,7 +60,7 @@ namespace Sipi {
             } else if (str.find("pct") != std::string::npos) {
                 size_type = SizeType::PERCENTS;
                 std::string percent_str = str.substr(4);
-                percent = shttps::Parsing::parse_double(percent_str);
+                percent = shttps::Parsing::parse_float(percent_str);
 
                 if (percent < 0.0) percent = 1.0;
                 if (percent > 100.0) percent = 100.0;

--- a/src/iiifparser/SipiSize.cpp
+++ b/src/iiifparser/SipiSize.cpp
@@ -51,7 +51,7 @@ namespace Sipi {
 
     SipiSize::SipiSize(std::string str) {
         nx = ny = 0;
-        percent = static_cast<float>(0.);
+        percent = 0.F;
         canonical_ok = false;
 
         try {
@@ -173,8 +173,8 @@ namespace Sipi {
     SipiSize::get_size(size_t img_w, size_t img_h, size_t &w_p, size_t &h_p, int &reduce_p, bool &redonly_p) {
         redonly = false;
 
-        double img_w_double = static_cast<double>(img_w);
-        double img_h_double = static_cast<double>(img_h);
+        float img_w_float = static_cast<float>(img_w);
+        float img_h_float = static_cast<float>(img_h);
 
         switch (size_type) {
             case SipiSize::PIXELS_XY: {
@@ -184,11 +184,11 @@ namespace Sipi {
                 int sf_w = 1;
                 int reduce_w = 0;
                 bool exact_match_w = true;
-                w = static_cast<size_t>(ceil(img_w_double / static_cast<double>(sf_w)));
+                w = static_cast<size_t>(ceilf(img_w_float / static_cast<float>(sf_w)));
 
                 while (w > nx) {
                     sf_w *= 2;
-                    w = static_cast<size_t>(ceil(img_w_double / static_cast<double>(sf_w)));
+                    w = static_cast<size_t>(ceilf(img_w_float / static_cast<float>(sf_w)));
                     reduce_w++;
                 }
 
@@ -202,11 +202,11 @@ namespace Sipi {
                 int sf_h = 1;
                 int reduce_h = 0;
                 bool exact_match_h = true;
-                h = static_cast<size_t>(ceil(img_h_double / static_cast<double>(sf_h)));
+                h = static_cast<size_t>(ceilf(img_h_float / static_cast<float>(sf_h)));
 
                 while (h > ny) {
                     sf_h *= 2;
-                    h = static_cast<size_t>(ceil(img_h_double / static_cast<double>(sf_h)));
+                    h = static_cast<size_t>(ceilf(img_h_float / static_cast<float>(sf_h)));
                     reduce_h++;
                 }
 
@@ -237,10 +237,10 @@ namespace Sipi {
                 int sf_w = 1;
                 int reduce_w = 0;
                 bool exact_match_w = true;
-                w = static_cast<size_t>(ceil(img_w_double / static_cast<double>(sf_w)));
+                w = static_cast<size_t>(ceilf(img_w_float / static_cast<float>(sf_w)));
                 while (w > nx) {
                     sf_w *= 2;
-                    w = static_cast<size_t>(ceil(img_w_double / static_cast<double>(sf_w)));
+                    w = static_cast<size_t>(ceilf(img_w_float / static_cast<float>(sf_w)));
                     reduce_w++;
                 }
                 if (w != nx) {
@@ -255,9 +255,9 @@ namespace Sipi {
                 redonly = exact_match_w; // if exact_match, then reduce only
 
                 if (exact_match_w) {
-                    h = static_cast<size_t>(ceil(img_h_double / static_cast<double>(sf_w)));
+                    h = static_cast<size_t>(ceilf(img_h_float / static_cast<float>(sf_w)));
                 } else {
-                    h = static_cast<size_t>(ceil(static_cast<double>(img_h * nx) / img_w_double));
+                    h = static_cast<size_t>(ceilf(static_cast<float>(img_h * nx) / img_w_float));
                 }
 
                 break;
@@ -270,11 +270,11 @@ namespace Sipi {
                 int sf_h = 1;
                 int reduce_h = 0;
                 bool exact_match_h = true;
-                h = static_cast<size_t>(ceil(img_h_double / static_cast<double>(sf_h)));
+                h = static_cast<size_t>(ceilf(img_h_float / static_cast<float>(sf_h)));
 
                 while (h > ny) {
                     sf_h *= 2;
-                    h = static_cast<size_t>(ceil(img_h_double / static_cast<double>(sf_h)));
+                    h = static_cast<size_t>(ceilf(img_h_float / static_cast<float>(sf_h)));
                     reduce_h++;
                 }
 
@@ -290,21 +290,21 @@ namespace Sipi {
                 redonly = exact_match_h; // if exact_match, then reduce only
 
                 if (exact_match_h) {
-                    w = static_cast<size_t>(ceil(img_w_double / static_cast<double>(sf_h)));
+                    w = static_cast<size_t>(ceilf(img_w_float / static_cast<float>(sf_h)));
                 } else {
-                    w = static_cast<size_t>(ceil(static_cast<double>(img_w * ny) / img_h_double));
+                    w = static_cast<size_t>(ceilf(static_cast<float>(img_w * ny) / img_h_float));
                 }
 
                 break;
             }
 
             case SipiSize::PERCENTS: {
-                w = static_cast<size_t>(ceil(img_w * percent / 100.F));
-                h = static_cast<size_t>(ceil(img_h * percent / 100.F));
+                w = static_cast<size_t>(ceilf(img_w * percent / 100.F));
+                h = static_cast<size_t>(ceilf(img_h * percent / 100.F));
 
                 reduce = 0;
-                double r = 100. / percent;
-                double s = 1.0;
+                float r = 100.F / percent;
+                float s = 1.0;
 
                 while (2.0 * s <= r) {
                     s *= 2.0;
@@ -328,27 +328,27 @@ namespace Sipi {
                 int sf = 1;
                 for (int i = 0; i < reduce; i++) sf *= 2;
 
-                w = static_cast<size_t>(ceil(img_w_double / static_cast<double>(sf)));
-                h = static_cast<size_t>(ceil(img_h_double / static_cast<double>(sf)));
+                w = static_cast<size_t>(ceilf(img_w_float / static_cast<float>(sf)));
+                h = static_cast<size_t>(ceilf(img_h_float / static_cast<float>(sf)));
                 redonly = true;
                 break;
             }
 
             case SipiSize::MAXDIM: {
-                float fx = (float) nx / (float) img_w;
-                float fy = (float) ny / (float) img_h;
+                float fx = static_cast<float>(nx) / img_w_float;
+                float fy = static_cast<float>(ny) / img_h_float;
 
                 float r;
                 if (fx < fy) { // scaling has to be done by fx
                     w = nx;
-                    h = static_cast<size_t>(ceil(img_h * fx));
+                    h = static_cast<size_t>(ceilf(img_h * fx));
 
-                    r = (float) img_w / (float) w;
+                    r = img_w_float / static_cast<float>(w);
                 } else { // scaling has to be done fy
-                    w = static_cast<size_t>(ceil(img_w * fy));
+                    w = static_cast<size_t>(ceilf(img_w * fy));
                     h = ny;
 
-                    r = (float) img_h / (float) h;
+                    r = img_h_float / static_cast<float>(h);
                 }
 
                 float s = 1.0;

--- a/src/iiifparser/SipiSize.cpp
+++ b/src/iiifparser/SipiSize.cpp
@@ -97,7 +97,7 @@ namespace Sipi {
                         throw SipiError(__file__, __LINE__, "IIIF height cannot be zero");
                     }
 
-                    size_type = SizeType::PIXELS_X;
+                    size_type = SizeType::PIXELS_Y;
                 } else if (height_str.empty()) {
                     nx = shttps::Parsing::parse_int(width_str);
 

--- a/src/sipi.cpp
+++ b/src/sipi.cpp
@@ -45,7 +45,7 @@
 #include "optionparser.h"
 
 #include "jansson.h"
-#include "shttps/GetMimetype.h"
+#include "shttps/Parsing.h"
 #include "SipiConf.h"
 
 // A macro for silencing incorrect compiler warnings about unused variables.
@@ -628,20 +628,7 @@ int main(int argc, char *argv[]) {
             size = std::make_shared<Sipi::SipiSize>(reduce);
         } else if (options[SIZE]) {
             try {
-                std::stringstream ss(options[SIZE].arg);
-                std::vector<int> sizV;
-                int sizC;
-                while (ss >> sizC) {
-                    sizV.push_back(sizC);
-                    if (ss.peek() == ',') {
-                        ss.ignore();
-                    }
-                }
-                if (sizV.size() == 2) {
-                    size = std::make_shared<Sipi::SipiSize>(sizV.at(0), sizV.at(1));
-                } else {
-                    size = std::make_shared<Sipi::SipiSize>(sizV.at(0), sizV.at(0), true);
-                }
+                size = std::make_shared<Sipi::SipiSize>(options[SIZE].arg);
             }
             catch (std::exception &e) {
                 std::cout << "##" << __LINE__ << std::endl;
@@ -667,7 +654,7 @@ int main(int argc, char *argv[]) {
         if (format == "jpg") {
             img.to8bps();
             if (img.getNalpha() > 0) {
-                img.removeChan(img.getNc() - 1);
+                img.removeChan(static_cast<unsigned int>(img.getNc() - 1));
             }
         }
 


### PR DESCRIPTION
This fixes two IIIF validation errors, so the IIIF validation tests always pass:

* Fixes #97.
* Fixes #122.

Summary of changes:

* Change the constructors of `SipiSize` and `SipiRotation` to make Sipi return a 400 Bad Request error when the IIIF size or rotation parameters are invalid.
* Collect parsing functions for integers, floats, and MIME types in `shttps::Parsing`.
* Construct a `SipiSize` on the stack instead of on the heap in `SipiLua.cpp`.
* Replace some `int` with `size_t`.
* Replace some C-style casts with `static_cast` (especially in `SipiSize.cpp`).
* Reformat some code for readability.
