### PR TITLE
fix (SipiRotation): Fix mirroring when Sipi is compiled with gcc

### DIFF
--- a/include/iiifparser/SipiRotation.h
+++ b/include/iiifparser/SipiRotation.h
@@ -31,13 +31,10 @@ namespace Sipi {
 //
     class SipiRotation {
     private:
-        bool mirror;
-        float rotation;
+        bool mirror = false;
+        float rotation = 0.F;
     public:
-        inline SipiRotation() {
-            mirror = false;
-            rotation = 0.F;
-        }
+        SipiRotation();
 
         SipiRotation(std::string str);
 

--- a/src/iiifparser/SipiRotation.cpp
+++ b/src/iiifparser/SipiRotation.cpp
@@ -44,6 +44,8 @@ static const char __file__[] = __FILE__;
 
 namespace Sipi {
 
+    SipiRotation::SipiRotation() { }
+
     SipiRotation::SipiRotation(std::string str) {
         try {
             if (str.empty()) {


### PR DESCRIPTION
This fixes a bug in `SipiRotation` when compiled with `gcc`. I don't know why, but the `mirror` member variable wasn't always initialised to `false`, so images would be randomly mirrored. I fixed it by moving initialisation to the variable declaration.

Fixes #127.