### PR TITLE
build on macos, typo and issue

### DIFF
--- a/manual/building.rst
+++ b/manual/building.rst
@@ -68,7 +68,7 @@ You will need Homebrew_. Then:
     brew install cmake
     brew install doxygen
     brew install openssl
-    brew inwtall libmagic
+    brew install libmagic
     brew install gettext
     brew install nginx
     sudo chown -R $USER /usr/local/var/log/nginx/

--- a/manual/building.rst
+++ b/manual/building.rst
@@ -60,7 +60,7 @@ which are specified in the file ``Color Profile EULA.pdf``.
 Mac OS X
 ========
 
-You will need Homebrew_. Then:
+You will need Homebrew_ and at least OSX 10.11.5. Then:
 
 ::
 


### PR DESCRIPTION
there was a typo (see commit)

there is a prerequisite to use `macOS Sierra`, at least, building on Yosemite, default `clang` is outdated, when trying to install `XCode`, Apple proposes xcode 8, which implies a `Serra` upgrade.
I guess it would be the same on `El Capitan`.