### PR TITLE
Wip/libmagic check

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,7 +116,11 @@ set(CMAKE_INSTALL_PREFIX ${COMMON_LOCAL})
 set(CONFIGURE_LIBDIR ${CMAKE_INSTALL_PREFIX}/lib)
 set(CMAKE_INSTALL_LIBDIR  ${CMAKE_INSTALL_PREFIX}/lib)
 
-
+#
+# libmagic
+# (used to be build locally from source was moved to prerequisites)
+#
+find_package(LibMagic REQUIRED)
 
 #
 # OpenSSL ??

--- a/cmake/Modules/FindLibMagic.cmake
+++ b/cmake/Modules/FindLibMagic.cmake
@@ -1,0 +1,52 @@
+# - Try to find libmagic header and library
+#
+# Usage of this module as follows:
+#
+#     find_package(LibMagic)
+#
+# Variables used by this module, they can change the default behaviour and need
+# to be set before calling find_package:
+#
+#  LibMagic_ROOT_DIR         Set this variable to the root installation of
+#                            libmagic if the module has problems finding the
+#                            proper installation path.
+#
+# Variables defined by this module:
+#
+#  LIBMAGIC_FOUND              System has libmagic and magic.h
+#  LibMagic_LIBRARY            The libmagic library
+#  LibMagic_INCLUDE_DIR        The location of magic.h
+
+find_path(LibMagic_ROOT_DIR
+    NAMES include/magic.h
+)
+
+if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+    # the static version of the library is preferred on OS X for the
+    # purposes of making packages (libmagic doesn't ship w/ OS X)
+    set(libmagic_names libmagic.a magic)
+else ()
+    set(libmagic_names magic)
+endif ()
+
+find_library(LibMagic_LIBRARY
+    NAMES ${libmagic_names}
+    HINTS ${LibMagic_ROOT_DIR}/lib
+)
+
+find_path(LibMagic_INCLUDE_DIR
+    NAMES magic.h
+    HINTS ${LibMagic_ROOT_DIR}/include
+)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(LibMagic DEFAULT_MSG
+    LibMagic_LIBRARY
+    LibMagic_INCLUDE_DIR
+)
+
+mark_as_advanced(
+    LibMagic_ROOT_DIR
+    LibMagic_LIBRARY
+    LibMagic_INCLUDE_DIR
+)

--- a/shttps/CMakeLists.txt
+++ b/shttps/CMakeLists.txt
@@ -113,25 +113,25 @@ add_dependencies(jansson project_jansson)
 #
 # get libmagic
 #
-Externalproject_Add(
-        project_magic
-        INSTALL_DIR ${CMAKE_CURRENT_SOURCE_DIR}/local
-        URL https://github.com/threatstack/libmagic/archive/master.zip
-        SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/lib/libmagic-master
-        CONFIGURE_COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/lib/libmagic-master/configure --prefix=${CMAKE_CURRENT_SOURCE_DIR}/local  --enable-shared --enable-static
-        BUILD_COMMAND make
-        INSTALL_COMMAND make install INSTALL_TOP=${CMAKE_CURRENT_SOURCE_DIR}/local
-        BUILD_IN_SOURCE 1
-)
-ExternalProject_Get_Property(project_magic install_dir)
-if(MAKE_SHARED_SHTTPS)
-    add_library(magic SHARED IMPORTED)
-    set_property(TARGET magic PROPERTY IMPORTED_LOCATION ${install_dir}/lib/libmagic${CMAKE_SHARED_LIBRARY_SUFFIX})
-else()
-    add_library(magic STATIC IMPORTED)
-    set_property(TARGET magic PROPERTY IMPORTED_LOCATION ${install_dir}/lib/libmagic${CMAKE_STATIC_LIBRARY_SUFFIX})
-endif()
-add_dependencies(magic project_magic)
+#Externalproject_Add(
+#        project_magic
+#        INSTALL_DIR ${CMAKE_CURRENT_SOURCE_DIR}/local
+#        URL https://github.com/threatstack/libmagic/archive/master.zip
+#        SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/lib/libmagic-master
+#        CONFIGURE_COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/lib/libmagic-master/configure --prefix=${CMAKE_CURRENT_SOURCE_DIR}/local  --enable-shared --enable-static
+#        BUILD_COMMAND make
+#        INSTALL_COMMAND make install INSTALL_TOP=${CMAKE_CURRENT_SOURCE_DIR}/local
+#        BUILD_IN_SOURCE 1
+#)
+#ExternalProject_Get_Property(project_magic install_dir)
+#if(MAKE_SHARED_SHTTPS)
+#    add_library(magic SHARED IMPORTED)
+#    set_property(TARGET magic PROPERTY IMPORTED_LOCATION ${install_dir}/lib/libmagic${CMAKE_SHARED_LIBRARY_SUFFIX})
+#else()
+#    add_library(magic STATIC IMPORTED)
+#    set_property(TARGET magic PROPERTY IMPORTED_LOCATION ${install_dir}/lib/libmagic${CMAKE_STATIC_LIBRARY_SUFFIX})
+#endif()
+#add_dependencies(magic project_magic)
 
 
 message(STATUS " SERVER-DIR: ${CMAKE_CURRENT_SOURCE_DIR}")

--- a/shttps/CMakeLists.txt
+++ b/shttps/CMakeLists.txt
@@ -110,30 +110,6 @@ add_library(jansson STATIC IMPORTED)
 set_property(TARGET jansson PROPERTY IMPORTED_LOCATION ${install_dir}/lib/libjansson${CMAKE_STATIC_LIBRARY_SUFFIX})
 add_dependencies(jansson project_jansson)
 
-#
-# get libmagic
-#
-#Externalproject_Add(
-#        project_magic
-#        INSTALL_DIR ${CMAKE_CURRENT_SOURCE_DIR}/local
-#        URL https://github.com/threatstack/libmagic/archive/master.zip
-#        SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/lib/libmagic-master
-#        CONFIGURE_COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/lib/libmagic-master/configure --prefix=${CMAKE_CURRENT_SOURCE_DIR}/local  --enable-shared --enable-static
-#        BUILD_COMMAND make
-#        INSTALL_COMMAND make install INSTALL_TOP=${CMAKE_CURRENT_SOURCE_DIR}/local
-#        BUILD_IN_SOURCE 1
-#)
-#ExternalProject_Get_Property(project_magic install_dir)
-#if(MAKE_SHARED_SHTTPS)
-#    add_library(magic SHARED IMPORTED)
-#    set_property(TARGET magic PROPERTY IMPORTED_LOCATION ${install_dir}/lib/libmagic${CMAKE_SHARED_LIBRARY_SUFFIX})
-#else()
-#    add_library(magic STATIC IMPORTED)
-#    set_property(TARGET magic PROPERTY IMPORTED_LOCATION ${install_dir}/lib/libmagic${CMAKE_STATIC_LIBRARY_SUFFIX})
-#endif()
-#add_dependencies(magic project_magic)
-
-
 message(STATUS " SERVER-DIR: ${CMAKE_CURRENT_SOURCE_DIR}")
 include_directories(AFTER ${CMAKE_CURRENT_SOURCE_DIR}/local/include ${CMAKE_CURRENT_SOURCE_DIR}/spdlog)
 add_library(


### PR DESCRIPTION
`libmagic` has moved from a dependencies compiled from source within the project to an external prerequisite in #104 .

I happened to miss this information and scratch my head on build errors, mislead by code in  `shttps/CMakeLists.txt`.

This is a proposition to check that `libmagic` is installed (`FindLibMagic.cmake` stolen from the BSD [bro project](https://www.bro.org/)) and to clean-up `shttps/CMakeLists.txt`.