### PR TITLE
moving to more recent version

### DIFF
--- a/ext/png/CMakeLists.txt
+++ b/ext/png/CMakeLists.txt
@@ -8,7 +8,7 @@ include(ExternalProject)
 ExternalProject_Add(
         project_png
         INSTALL_DIR ${COMMON_LOCAL}
-        URL https://sourceforge.net/projects/libpng/files/libpng16/1.6.27/libpng-1.6.27.tar.gz/download
+        URL https://sourceforge.net/projects/libpng/files/libpng16/1.6.29/libpng-1.6.29.tar.xz/download
         DOWNLOAD_NAME libpng-latest.tar.xz
         #URL https://sourceforge.net/projects/libpng/files/latest/download?source=files
         SOURCE_DIR ${COMMON_SRCS}/libpng-latest

--- a/ext/png/CMakeLists.txt
+++ b/ext/png/CMakeLists.txt
@@ -8,8 +8,8 @@ include(ExternalProject)
 ExternalProject_Add(
         project_png
         INSTALL_DIR ${COMMON_LOCAL}
-        URL https://sourceforge.net/projects/libpng/files/libpng16/1.6.29/libpng-1.6.29.tar.xz/download
-        DOWNLOAD_NAME libpng-latest.tar.xz
+        URL https://sourceforge.net/projects/libpng/files/libpng16/1.6.29/libpng-1.6.29.tar.gz/download
+        DOWNLOAD_NAME libpng-latest.tar.gz
         #URL https://sourceforge.net/projects/libpng/files/latest/download?source=files
         SOURCE_DIR ${COMMON_SRCS}/libpng-latest
         CMAKE_ARGS -DPNG_SHARED:BOOL=OFF -DCMAKE_INSTALL_PREFIX=${COMMON_LOCAL} -DCMAKE_INSTALL_LIBDIR=${CONFIGURE_LIBDIR}


### PR DESCRIPTION
as often:
- the named version (1.6.27) of png was not available anymore (they don't keep more than the last 2 revisions)
- the generic `download latest` does not work either (file location and build script incompatibilities)
- we don't cache third party software distribution yet

so this is a temporary fix; moving to a more recent named version of libpng