### PR TITLE
parse Knora session id from cookie

### DIFF
--- a/config/sipi.fake-knora-test-config.lua
+++ b/config/sipi.fake-knora-test-config.lua
@@ -167,5 +167,10 @@ routes = {
         method = 'GET',
         route = '/test_functions',
         script = 'test_functions.lua'
+    },
+    {
+        method = 'GET',
+        route = '/test_knora_session_cookie',
+        script = 'test_knora_session_cookie.lua'
     }
 }

--- a/config/sipi.init-debug.lua
+++ b/config/sipi.init-debug.lua
@@ -19,6 +19,8 @@
 -- You should have received a copy of the GNU Affero General Public
 -- License along with Sipi.  If not, see <http://www.gnu.org/licenses/>.
 
+require "get_knora_session"
+
 -------------------------------------------------------------------------------
 -- This function is being called from sipi before the file is served
 -- Knora is called to ask for the user's permissions on the file
@@ -67,7 +69,7 @@ function pre_flight(prefix,identifier,cookie)
         -- tries to extract the Knora session id from the cookie:
         -- gets the digits between "sid=" and the closing ";" (only given in case of several key value pairs)
         -- returns nil if it cannot find it
-        session_id = string.match(cookie, "sid=(%d+);?")
+        session_id = get_session_id(cookie)
 
         if session_id == nil then
             -- no session_id could be extracted

--- a/config/sipi.init-knora-test.lua
+++ b/config/sipi.init-knora-test.lua
@@ -19,6 +19,8 @@
 -- You should have received a copy of the GNU Affero General Public
 -- License along with Sipi.  If not, see <http://www.gnu.org/licenses/>.
 
+require "get_knora_session"
+
 -------------------------------------------------------------------------------
 -- This function is being called from sipi before the file is served
 -- Knora is called to ask for the user's permissions on the file
@@ -71,7 +73,7 @@ function pre_flight(prefix,identifier,cookie)
         -- tries to extract the Knora session id from the cookie:
         -- gets the digits between "sid=" and the closing ";" (only given in case of several key value pairs)
         -- returns nil if it cannot find it
-        session_id = string.match(cookie, "sid=(%d+);?")
+        session_id = get_session_id(cookie)
 
         if session_id == nil then
             -- no session_id could be extracted

--- a/config/sipi.init-knora.lua
+++ b/config/sipi.init-knora.lua
@@ -66,7 +66,7 @@ function pre_flight(prefix, identifier, cookie)
         -- tries to extract the Knora session id from the cookie:
         -- gets the digits between "sid=" and the closing ";" (only given in case of several key value pairs)
         -- returns nil if it cannot find it
-        session_id = string.match(cookie, "sid=(%d+);?")
+        session_id = string.match(cookie, "sid=([^%s;]+)")
 
         if session_id == nil then
             -- no session_id could be extracted

--- a/config/sipi.init-knora.lua
+++ b/config/sipi.init-knora.lua
@@ -19,6 +19,8 @@
 -- You should have received a copy of the GNU Affero General Public
 -- License along with Sipi.  If not, see <http://www.gnu.org/licenses/>.
 
+require "get_knora_session"
+
 -------------------------------------------------------------------------------
 -- This function is being called from sipi before the file is served
 -- Knora is called to ask for the user's permissions on the file
@@ -36,7 +38,6 @@
 --    filepath: server-path where the master file is located
 -------------------------------------------------------------------------------
 function pre_flight(prefix, identifier, cookie)
-
 
     if config.prefix_as_path then
         filepath = config.imgroot .. '/' .. prefix .. '/' .. identifier
@@ -66,7 +67,7 @@ function pre_flight(prefix, identifier, cookie)
         -- tries to extract the Knora session id from the cookie:
         -- gets the digits between "sid=" and the closing ";" (only given in case of several key value pairs)
         -- returns nil if it cannot find it
-        session_id = string.match(cookie, "sid=([^%s;]+)")
+        session_id = get_session_id(cookie)
 
         if session_id == nil then
             -- no session_id could be extracted

--- a/scripts/Knora_login.lua
+++ b/scripts/Knora_login.lua
@@ -22,7 +22,12 @@
 
 -- create a cookie containing the Knora session id
 
-server.setBuffer()
+local success, errormsg = server.setBuffer()
+if not success then
+    server.log("server.setBuffer() failed: " .. errormsg, server.loglevel.LOG_ERR)
+    send_error(500, "buffer could not be set correctly")
+    return
+end
 
 sessionId = server.post['sid']
 
@@ -34,5 +39,15 @@ if sessionId == nil then
 end
 
 -- set the cookie HttpOnly
-server.sendHeader("Set-Cookie", "sid=" .. sessionId .. ";HttpOnly")
+local success, errormsg = server.sendHeader("Set-Cookie", "sid=" .. sessionId .. ";HttpOnly")
+if not success then
+    print(errormsg)
+end
+
+-- set content-type to text
+-- jQuery in SALSAH expects a content-type
+local success, errormsg = server.sendHeader("Content-Type", "text/plain")
+if not success then
+    print(">>>1 ", errormsg)
+end
 

--- a/scripts/Knora_logout.lua
+++ b/scripts/Knora_logout.lua
@@ -22,8 +22,22 @@
 
 -- destroy the cookie containing the Knora session id
 
-server.setBuffer()
+local success, errormsg = server.setBuffer()
+if not success then
+    server.log("server.setBuffer() failed: " .. errormsg, server.loglevel.LOG_ERR)
+    send_error(500, "buffer could not be set correctly")
+    return
+end
 
 -- invalidate cookie
-server.sendHeader("Set-Cookie", "sid=deleted;Expires=Thu, 01 Jan 1970 00:00:00 GMT")
+local success, errormsg = server.sendHeader("Set-Cookie", "sid=deleted;Expires=Thu, 01 Jan 1970 00:00:00 GMT")
+if not success then
+    print(errormsg)
+end
 
+-- set content-type to text
+-- jQuery in SALSAH expects a content-type
+local success, errormsg = server.sendHeader("Content-Type", "text/plain")
+if not success then
+    print(">>>1 ", errormsg)
+end

--- a/scripts/get_knora_session.lua
+++ b/scripts/get_knora_session.lua
@@ -37,7 +37,9 @@ function get_session_id(cookie)
 
     -- tries to extract the Knora session id from the cookie:
     -- gets the digits between "sid=" and the closing ";" (only given in case of several key value pairs)
-    -- returns nil if it cannot find it
+    -- ";" is expected to separate different key value pairs (https://tools.ietf.org/html/rfc6265#section-4.2.1)
+    -- space is also treated as a separator
+    -- returns nil if it cannot find the session id (pattern does not match)
     session_id = string.match(cookie, "sid=([^%s;]+)")
 
     return session_id

--- a/scripts/get_knora_session.lua
+++ b/scripts/get_knora_session.lua
@@ -1,0 +1,46 @@
+
+--
+-- Copyright © 2016 Lukas Rosenthaler, Andrea Bianco, Benjamin Geer,
+-- Ivan Subotic, Tobias Schweizer, André Kilchenmann, and André Fatton.
+-- This file is part of Sipi.
+-- Sipi is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU Affero General Public License as published
+-- by the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+-- Sipi is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+-- Additional permission under GNU AGPL version 3 section 7:
+-- If you modify this Program, or any covered work, by linking or combining
+-- it with Kakadu (or a modified version of that library), containing parts
+-- covered by the terms of the Kakadu Software Licence, the licensors of this
+-- Program grant you additional permission to convey the resulting work.
+-- See the GNU Affero General Public License for more details.
+-- You should have received a copy of the GNU Affero General Public
+-- License along with Sipi.  If not, see <http://www.gnu.org/licenses/>.
+
+-------------------------------------------------------------------------------
+-- This function is called from the route to get the Knora session id from the cookie.
+-- The cookie is sent to Sipi by the client (HTTP request header).
+-- Parameters:
+--     'cookie' (string):  cookie from the HTTP request header
+--
+-- Returns:
+--    the Knora session id or `nil` if it could not be found
+-------------------------------------------------------------------------------
+function get_session_id(cookie)
+
+    if (type(cookie) ~= "string") then
+        server.log("parameter 'cookie' for function 'get_session_id' is expected to be a string", server.loglevel.LOG_ERR)
+        return nil
+    end
+
+    -- tries to extract the Knora session id from the cookie:
+    -- gets the digits between "sid=" and the closing ";" (only given in case of several key value pairs)
+    -- returns nil if it cannot find it
+    session_id = string.match(cookie, "sid=([^%s;]+)")
+
+    return session_id
+
+end
+

--- a/scripts/test_knora_session_cookie.lua
+++ b/scripts/test_knora_session_cookie.lua
@@ -1,0 +1,82 @@
+--
+-- Copyright © 2016 Lukas Rosenthaler, Andrea Bianco, Benjamin Geer,
+-- Ivan Subotic, Tobias Schweizer, André Kilchenmann, and André Fatton.
+-- This file is part of Sipi.
+-- Sipi is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU Affero General Public License as published
+-- by the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+-- Sipi is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+-- Additional permission under GNU AGPL version 3 section 7:
+-- If you modify this Program, or any covered work, by linking or combining
+-- it with Kakadu (or a modified version of that library), containing parts
+-- covered by the terms of the Kakadu Software Licence, the licensors of this
+-- Program grant you additional permission to convey the resulting work.
+-- See the GNU Affero General Public License for more details.
+-- You should have received a copy of the GNU Affero General Public
+-- License along with Sipi.  If not, see <http://www.gnu.org/licenses/>.
+
+require "send_response"
+require "get_knora_session"
+
+success, errmsg = server.setBuffer()
+
+if not success then
+    server.log("server.setBuffer() failed: " .. errmsg, server.loglevel.LOG_ERR)
+    send_error(500, "buffer could not be set correctly")
+    return
+end
+
+local test_cookie_headers = {
+    {
+        header = "sid=2cdbbac3-77d3-454d-8e30-e75e6952a81b",
+        session_id = "2cdbbac3-77d3-454d-8e30-e75e6952a81b"
+    },
+    {
+        header = "sid=2cdbbac3-77d3-454d-8e30-e75e6952a81b ",
+        session_id = "2cdbbac3-77d3-454d-8e30-e75e6952a81b"
+    },
+    {
+        header = "sid=2cdbbac3-77d3-454d-8e30-e75e6952a81b;",
+        session_id = "2cdbbac3-77d3-454d-8e30-e75e6952a81b"
+    }, {
+        header = "sid=2cdbbac3-77d3-454d-8e30-e75e6952a81b; ",
+        session_id = "2cdbbac3-77d3-454d-8e30-e75e6952a81b"
+    }, {
+        header = "sid=2cdbbac3-77d3-454d-8e30-e75e6952a81b;other=true;",
+        session_id = "2cdbbac3-77d3-454d-8e30-e75e6952a81b"
+    }, {
+        header = "sid=2cdbbac3-77d3-454d-8e30-e75e6952a81b; other=true;",
+        session_id = "2cdbbac3-77d3-454d-8e30-e75e6952a81b"
+    }, {
+        header = "other=true; sid=2cdbbac3-77d3-454d-8e30-e75e6952a81b",
+        session_id = "2cdbbac3-77d3-454d-8e30-e75e6952a81b"
+    }, {
+        header = "other=true;sid=2cdbbac3-77d3-454d-8e30-e75e6952a81b",
+        session_id = "2cdbbac3-77d3-454d-8e30-e75e6952a81b"
+    }, {
+        header = "other=true;sid=2cdbbac3-77d3-454d-8e30-e75e6952a81b;other2=true",
+        session_id = "2cdbbac3-77d3-454d-8e30-e75e6952a81b"
+    }, {
+        header = "other=true;sid=2cdbbac3-77d3-454d-8e30-e75e6952a81b; other2=true",
+        session_id = "2cdbbac3-77d3-454d-8e30-e75e6952a81b"
+    }
+}
+
+for i, cookie_item in ipairs(test_cookie_headers) do
+
+    local session_id = get_session_id(cookie_item.header)
+
+    if session_id == nil or session_id ~= cookie_item.session_id then
+        send_error(400, "Knora session id could not be parsed correctly from cookie: " .. cookie_item.header)
+        return -1
+    end
+end
+
+result = {
+    result = "ok"
+}
+
+send_success(result)

--- a/shttps/LuaServer.cpp
+++ b/shttps/LuaServer.cpp
@@ -303,7 +303,7 @@ namespace shttps {
      *
      * \param[in] luafile A file containing a Lua script or a Lua code chunk
      */
-    LuaServer::LuaServer(Connection &conn, const std::string &luafile, bool iscode) {
+    LuaServer::LuaServer(Connection &conn, const std::string &luafile, bool iscode, const std::string &lua_scriptdir) {
         if ((L = luaL_newstate()) == nullptr) {
             throw new Error(__file__, __LINE__, "Couldn't start lua interpreter");
         }
@@ -311,6 +311,10 @@ namespace shttps {
         lua_atpanic(L, dont_panic);
         luaL_openlibs(L);
         createGlobals(conn);
+
+        // add the script directory to the standard search path for lua packages
+        // this allows for the inclusion of Lua scripts contained in the Lua script directory
+        this->setLuaPath(lua_scriptdir);
 
         if (!luafile.empty()) {
             if (iscode) {

--- a/shttps/LuaServer.h
+++ b/shttps/LuaServer.h
@@ -96,8 +96,9 @@ namespace shttps {
          * \param[in] conn HTTP Connection object
          * \param[in] luafile A script containing lua commands
          * \param[in] iscode If true, the string contains lua-code to be executed directly
+         * \param[in] lua_scriptdir Pattern to be added to the Lua package.path (directory with Lua scripts)
          */
-        LuaServer(Connection &conn, const std::string &luafile, bool iscode);
+        LuaServer(Connection &conn, const std::string &luafile, bool iscode, const std::string &lua_scriptdir);
 
         /*!
          * Copy constructor throws error (not allowed!)

--- a/shttps/Server.cpp
+++ b/shttps/Server.cpp
@@ -1133,9 +1133,12 @@ namespace shttps {
             //
             // Setting up the Lua server
             //
-            LuaServer luaserver(conn, _initscript, true);
-            luaserver.setLuaPath(
-                    _scriptdir + "/?.lua"); // add the script dir to the standard search path fpr lua packages
+
+            // pattern to be added to the Lua package.path
+            // includes Lua files in the Lua script directory
+            std::string lua_scriptdir = _scriptdir + "/?.lua";
+
+            LuaServer luaserver(conn, _initscript, true, lua_scriptdir);
 
             for (auto &global_func : lua_globals) {
                 global_func.func(luaserver.lua(), conn, global_func.func_dataptr);

--- a/shttps/Server.h
+++ b/shttps/Server.h
@@ -215,7 +215,7 @@ namespace shttps {
 
         int stoppipe[2];
         std::string _tmpdir; //!< path to directory, where uplaods are being stored
-        std::string _scriptdir; //!< Path to directory, thwere scripts for the "Lua"-routes are found
+        std::string _scriptdir; //!< Path to directory, where scripts for the "Lua"-routes are found
         unsigned _nthreads; //!< maximum number of parallel threads for processing requests
         std::string semname; //!< name of the semaphore for restricting the number of threads
         sem_t *_semaphore; //!< semaphore

--- a/shttps/Shttp.cpp
+++ b/shttps/Shttp.cpp
@@ -204,8 +204,8 @@ int main(int argc, char *argv[]) {
     if (!ssl_key.empty()) server.ssl_key(ssl_key);
     server.jwt_secret(jwt_secret);
 #endif
-    server.tmpdir(tmpdir); // set the directory for storing temporaray files during upload
-    server.scriptdir(scriptdir); // set the direcxtory where the Lua scripts are found for the "Lua"-routes
+    server.tmpdir(tmpdir); // set the directory for storing temporary files during upload
+    server.scriptdir(scriptdir); // set the directory where the Lua scripts are found for the "Lua"-routes
     server.max_post_size(max_post_size); // set the maximal post size
     server.luaRoutes(routes);
     server.keep_alive_timeout(keep_alive); // set the keep alive timeout

--- a/src/sipi.cpp
+++ b/src/sipi.cpp
@@ -443,8 +443,7 @@ int main(int argc, char *argv[]) {
             // set tmpdir for uploads (defined in sipi.config.lua)
             server.tmpdir(sipiConf.getTmpDir());
             server.max_post_size(sipiConf.getMaxPostSize());
-            server.scriptdir(
-                    sipiConf.getScriptDir()); // set the directory where the Lua scripts are found for the "Lua"-routes
+            server.scriptdir(sipiConf.getScriptDir()); // set the directory where the Lua scripts are found for the "Lua"-routes
             server.luaRoutes(sipiConf.getRoutes());
             server.add_lua_globals_func(sipiConfGlobals, &sipiConf);
             server.add_lua_globals_func(shttps::sqliteGlobals); // add new lua function "gaga"

--- a/test/test_basic.py
+++ b/test/test_basic.py
@@ -37,6 +37,10 @@ class TestBasic:
         """call C++ functions from Lua scripts"""
         manager.expect_status_code("/test_functions", 200)
 
+    def test_knora_session_parsing(self, manager):
+        """call Lua function that gets the Knora session id from the cookie header sent to Sipi"""
+        manager.expect_status_code("/test_knora_session_cookie", 200)
+
     def test_file_bytes(self, manager):
         """return an unmodified JPG file"""
         manager.compare_bytes("/knora/Leaves.jpg/full/full/0/default.jpg", "Leaves.jpg")


### PR DESCRIPTION
This pull request fixes the parsing of the Knora session id from the cookie sent to Sipi on an image request (HTTP request header).

The session used to be numeric, now it isn's anymore. The regex had to be adjusted accordingly.

I have put the regex in a central place ad added a test for it.

I have also added a fix so that the script dir for Lua is addd before any Lua file is loaded.

Sipi now returns a content-type on login and logout (needed for jQuery, see <https://github.com/dhlab-basel/Knora/pull/473>).

