### PR TITLE
fix (config): add subdir exludes to docker config

### DIFF
--- a/config/sipi.knora-docker-config.lua
+++ b/config/sipi.knora-docker-config.lua
@@ -75,6 +75,15 @@ sipi = {
     subdir_levels = 1,
 
     --
+    -- if subdir_levels is > 0 and if prefix_as_path is true, all prefixes will be
+    -- regarded as directories under imgroot. Thus, the subdirs 'A'-'Z' will be
+    -- created in these directories for the prefixes. However, it may make sense
+    -- for certain prefixes *not* to use subdirs. A list of these prefix-directories
+    -- can be given with this configuration parameter.
+    --
+    subdir_excludes = { "tmp", "thumbs"},
+
+    --
     -- Lua script which is executed on initialization of the Lua interpreter
     --
     initscript = '/sipi/config/sipi.init-knora.lua',
@@ -117,7 +126,12 @@ sipi = {
     --
     -- Port of Knora Application
     --
-    knora_port = '3333'
+    knora_port = '3333',
+
+    --
+    -- loglevel, one of "EMERGENCY", "ALERT", "CRITICAL", "ERROR", "WARNING", "NOTICE", "INFORMATIONAL", "DEBUG"
+    --
+    loglevel = "DEBUG"
 
 }
 

--- a/config/sipi.knora-test-docker-config.lua
+++ b/config/sipi.knora-test-docker-config.lua
@@ -121,6 +121,14 @@ sipi = {
     --
     subdir_levels = 0,
 
+    --
+    -- if subdir_levels is > 0 and if prefix_as_path is true, all prefixes will be
+    -- regarded as directories under imgroot. Thus, the subdirs 'A'-'Z' will be
+    -- created in these directories for the prefixes. However, it may make sense
+    -- for certain prefixes *not* to use subdirs. A list of these prefix-directories
+    -- can be given with this configuration parameter.
+    --
+    subdir_excludes = { "tmp", "thumbs"},
 
     --
     -- Port of Knora Application
@@ -161,7 +169,7 @@ sipi = {
     --
     -- loglevel, one of "EMERGENCY", "ALERT", "CRITICAL", "ERROR", "WARNING", "NOTICE", "INFORMATIONAL", "DEBUG"
     --
-    loglevel = "DEBUG",
+    loglevel = "DEBUG"
 }
 
 fileserver = {


### PR DESCRIPTION
### Summary

This should have been part of the last PR, but I forgot to update the docker configs.

- add missing exclude dirs variable to docker configuration