### PR TITLE
Add 'unzip' to Ubuntu 16.04 prerequisites

### DIFF
--- a/manual/building.rst
+++ b/manual/building.rst
@@ -104,6 +104,7 @@ Prerequisites for building Sipi without its automated test framework:
     sudo apt-get install libreadline-dev
     sudo apt-get install gettext
     sudo apt-get install libmagic-dev
+    sudo apt-get install unzip
 
 If you also want to run Sipi's tests, you will need ImageMagick_, version 7.0.6
 or higher. We suggest compiling it from source:


### PR DESCRIPTION
In order to unzip Kakadu we also need unzip installed. Add `sudo apt-get install unzip` to prerequisites for Ubuntu 16.04