### PR TITLE
accept upper-case file extensions for mime type check

### DIFF
--- a/scripts/test_functions.lua
+++ b/scripts/test_functions.lua
@@ -93,7 +93,7 @@ for i, test_data_item in ipairs(mimetype_test_data) do
     table.insert(result, { test_data_item, "OK" })
 end
 
--- Try parsing something that should return an error.
+-- Try parsing a mimetype that should return an error.
 
 local success, parsed_bad_mimetype = server.parse_mimetype(bad_mimetype)
 

--- a/src/SipiImage.cpp
+++ b/src/SipiImage.cpp
@@ -237,6 +237,7 @@ namespace Sipi {
             }
 
             std::string extension = filename.substr(dot_pos + 1);
+            std::transform(extension.begin(), extension.end(), extension.begin(), ::tolower); // convert file extension to lower case (uppercase letters in file extension have to be converted for mime type comparison)
             std::string mime_from_extension = Sipi::SipiImage::mimetypes.at(extension);
 
             if (mime_from_extension != actual_mimetype) {


### PR DESCRIPTION
When creating an image, we check for the consistency of the mime type indicated by the user, the original file extension and the actual mime type (determined by libmagic).

In order to check if the file extension matches a mime type, we look it up in a map whose keys are all lower-case.

This PR converts the file extension to lower-case so also upper-case extensions are found in the map.