### PR TITLE
fix (test): missing libgtest

### DIFF
--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -26,7 +26,7 @@ add_dependencies(libgtest gtest)
 
 # Set libgtest properties
 set_target_properties(libgtest PROPERTIES
-        "IMPORTED_LOCATION" "${binary_dir}/googletest/libgtest.a"
+        "IMPORTED_LOCATION" "${binary_dir}/lib/libgtest.a"
         "IMPORTED_LINK_INTERFACE_LIBRARIES" "${CMAKE_THREAD_LIBS_INIT}"
         )
 
@@ -36,7 +36,7 @@ add_dependencies(libgmock gtest)
 
 # Set libgmock properties
 set_target_properties(libgmock PROPERTIES
-        "IMPORTED_LOCATION" "${binary_dir}/googlemock/libgmock.a"
+        "IMPORTED_LOCATION" "${binary_dir}/lib/libgmock.a"
         "IMPORTED_LINK_INTERFACE_LIBRARIES" "${CMAKE_THREAD_LIBS_INIT}"
         )
 

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -26,7 +26,7 @@ add_dependencies(libgtest gtest)
 
 # Set libgtest properties
 set_target_properties(libgtest PROPERTIES
-        "IMPORTED_LOCATION" "${binary_dir}/googlemock/gtest/libgtest.a"
+        "IMPORTED_LOCATION" "${binary_dir}/googletest/libgtest.a"
         "IMPORTED_LINK_INTERFACE_LIBRARIES" "${CMAKE_THREAD_LIBS_INIT}"
         )
 

--- a/test/unit/configuration/CMakeLists.txt
+++ b/test/unit/configuration/CMakeLists.txt
@@ -41,8 +41,7 @@ add_executable(
 
 target_link_libraries(
         configuration
-        libgtest
-        libgmock)
+        libgtest)
 
 # MESSAGE(STATUS "LIBS: " ${LIBS})
 target_link_libraries(configuration ${LIBS} lcms2 exiv2 expat jpeg tiff jbigkit png kdu_aux kdu xz magic lua jansson sqlite3 dl pthread curl ${CMAKE_DL_LIBS} z m)

--- a/test/unit/configuration/configuration.cpp
+++ b/test/unit/configuration/configuration.cpp
@@ -1,5 +1,4 @@
 #include "gtest/gtest.h"
-#include "gmock/gmock.h"
 
 #include "../../../shttps/LuaServer.h"
 #include "../../../include/SipiConf.h"

--- a/test/unit/sipiimage/CMakeLists.txt
+++ b/test/unit/sipiimage/CMakeLists.txt
@@ -62,8 +62,7 @@ add_dependencies(sipiimage icc_profiles)
 
 target_link_libraries(
         sipiimage
-        libgtest
-        libgmock)
+        libgtest)
 
 # MESSAGE(STATUS "LIBS: " ${LIBS})
 target_link_libraries(sipiimage ${LIBS} lcms2 exiv2 expat jpeg tiff jbigkit png kdu_aux kdu xz magic lua jansson sqlite3 dl pthread curl ${CMAKE_DL_LIBS} z m)

--- a/test/unit/sipiimage/sipiimage.cpp
+++ b/test/unit/sipiimage/sipiimage.cpp
@@ -1,5 +1,4 @@
 #include "gtest/gtest.h"
-#include "gmock/gmock.h"
 
 #include "../../../include/SipiImage.h"
 


### PR DESCRIPTION
### Summary

Upstream, the path where the libraries are stored after they are built has changed.

### Issues

- resolves #264 