### PR TITLE
bugfix info.json: return https if SSL is used

### DIFF
--- a/shttps/Server.cpp
+++ b/shttps/Server.cpp
@@ -463,7 +463,7 @@ namespace shttps {
     //=========================================================================
 
     Server::Server(int port_p, unsigned nthreads_p, const std::string userid_str, const std::string &logfile_p,
-                   const std::string &loglevel_p) : port(port_p), _nthreads(nthreads_p), _logfilename(logfile_p),
+                   const std::string &loglevel_p) : _port(port_p), _nthreads(nthreads_p), _logfilename(logfile_p),
                                                     _loglevel(loglevel_p) {
         _ssl_port = -1;
 
@@ -471,7 +471,7 @@ namespace shttps {
         // we use a semaphore object to control the number of threads
         //
         semname = "shttps";
-        semname += std::to_string(port);
+        semname += std::to_string(_port);
         _user_data = nullptr;
         running = false;
         _keep_alive_timeout = 20;
@@ -885,9 +885,9 @@ namespace shttps {
             setlogmask(old_ll);
         }
 
-        _sockfd = prepare_socket(port);
+        _sockfd = prepare_socket(_port);
         old_ll = setlogmask(LOG_MASK(LOG_INFO));
-        syslog(LOG_INFO, "Server listening on port %d", port);
+        syslog(LOG_INFO, "Server listening on port %d", _port);
         setlogmask(old_ll);
 
         if (_ssl_port > 0) {

--- a/shttps/Server.h
+++ b/shttps/Server.h
@@ -202,7 +202,7 @@ namespace shttps {
         //=========================================================================
 
     private:
-        int port; //!< listening Port for server
+        int _port; //!< listening Port for server
         int _ssl_port; //!< listening port for openssl
         int _sockfd; //!< socket id
         int _ssl_sockfd; //!< SSL socket id
@@ -270,6 +270,8 @@ namespace shttps {
         inline int semaphore_get() {
             return _semcnt;
         }
+
+        inline int port(void) { return _port; }
 
 #       ifdef SHTTPS_ENABLE_SSL
 

--- a/src/SipiHttpServer.cpp
+++ b/src/SipiHttpServer.cpp
@@ -384,8 +384,13 @@ namespace Sipi {
         json_object_set_new(root, "@context", json_string("http://iiif.io/api/image/2/context.json"));
 
         std::string host = conn_obj.header("host");
-        std::string id = std::string("http://") + host + "/" + params[iiif_prefix] + "/" +
-                         params[iiif_identifier]; //// ?????????????????????????????????????
+        std::string id;
+        if (conn_obj.secure()) {
+            id = std::string("https://") + host + "/" + params[iiif_prefix] + "/" + params[iiif_identifier];
+        }
+        else {
+            id = std::string("http://") + host + "/" + params[iiif_prefix] + "/" + params[iiif_identifier];
+        }
         json_object_set_new(root, "@id", json_string(id.c_str()));
 
         json_object_set_new(root, "protocol", json_string("http://iiif.io/api/image"));


### PR DESCRIPTION
Changed the output of info.json to use "https" for the image url if info.json is requested using https.

Its a small fix – please review ASAP
